### PR TITLE
Add methods from NodeEditor extension

### DIFF
--- a/imgui-binding/src/generated/java/imgui/ImDrawData.java
+++ b/imgui-binding/src/generated/java/imgui/ImDrawData.java
@@ -2,6 +2,9 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -13,6 +16,7 @@ import java.nio.ByteOrder;
  * BINDING NOTICE: Since it's impossible to do a 1:1 mapping with JNI, current class provides "getCmdList*()" methods.
  * Those are used to get the data needed to do a rendering.
  */
+
 public final class ImDrawData extends ImGuiStruct {
     private static final int RESIZE_FACTOR = 5_000;
     private static ByteBuffer dataBuffer = ByteBuffer.allocateDirect(25_000).order(ByteOrder.nativeOrder());
@@ -144,7 +148,7 @@ public final class ImDrawData extends ImGuiStruct {
 
     ///////// End of Render Methods
 
-    /**
+     /**
      * Only valid after Render() is called and before the next NewFrame() is called.
      */
     public boolean getValid() {
@@ -155,7 +159,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->Valid;
     */
 
-    /**
+     /**
      * Number of ImDrawList* to render
      */
     public int getCmdListsCount() {
@@ -166,7 +170,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->CmdListsCount;
     */
 
-    /**
+     /**
      * For convenience, sum of all ImDrawList's IdxBuffer.Size
      */
     public int getTotalIdxCount() {
@@ -177,7 +181,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->TotalIdxCount;
     */
 
-    /**
+     /**
      * For convenience, sum of all ImDrawList's VtxBuffer.Size
      */
     public int getTotalVtxCount() {
@@ -188,7 +192,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->TotalVtxCount;
     */
 
-    /**
+     /**
      * Upper-left position of the viewport to render (== upper-left of the orthogonal projection matrix to use)
      */
     public ImVec2 getDisplayPos() {
@@ -230,7 +234,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->DisplayPos.y;
     */
 
-    /**
+     /**
      * Size of the viewport to render (== io.DisplaySize for the main viewport)
      * (DisplayPos + DisplaySize == lower-right of the orthogonal projection matrix to use)
      */
@@ -276,7 +280,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->DisplaySize.y;
     */
 
-    /**
+     /**
      * Amount of pixels for each unit of DisplaySize. Based on io.DisplayFramebufferScale. Generally (1,1) on normal display, (2,2) on OSX with Retina display.
      */
     public ImVec2 getFramebufferScale() {
@@ -318,7 +322,7 @@ public final class ImDrawData extends ImGuiStruct {
         return THIS->FramebufferScale.y;
     */
 
-    /**
+     /**
      * Viewport carrying the ImDrawData instance, might be of use to the renderer (generally not).
      */
     public ImGuiViewport getOwnerViewport() {
@@ -339,7 +343,7 @@ public final class ImDrawData extends ImGuiStruct {
         THIS->Clear();
     */
 
-    /**
+     /**
      * Helper to add an external draw list into an existing ImDrawData.
      */
     public void addDrawList(final ImDrawList drawList) {
@@ -350,7 +354,7 @@ public final class ImDrawData extends ImGuiStruct {
         THIS->AddDrawList(reinterpret_cast<ImDrawList*>(drawList));
     */
 
-    /**
+     /**
      * Helper to convert all buffers from indexed to non-indexed, in case you cannot render indexed. Note: this is slow and most likely a waste of resources.
      * Always prefer indexed rendering!
      */
@@ -362,7 +366,7 @@ public final class ImDrawData extends ImGuiStruct {
         THIS->DeIndexAllBuffers();
     */
 
-    /**
+     /**
      * Helper to scale the ClipRect field of each ImDrawCmd. Use if your final output buffer is at a different scale than Dear ImGui expects,
      * or if there is a difference between your window resolution and framebuffer resolution.
      */

--- a/imgui-binding/src/generated/java/imgui/ImDrawList.java
+++ b/imgui-binding/src/generated/java/imgui/ImDrawList.java
@@ -2,6 +2,11 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
+
 /**
  * Draw command list
  * This is the low-level list of polygons that ImGui:: functions are filling. At the end of the frame,
@@ -13,6 +18,7 @@ import imgui.binding.ImGuiStruct;
  * but you are totally free to apply whatever transformation matrix to want to the data (if you apply such transformation you'll want to apply it to ClipRect as well)
  * Important: Primitives are always added to the list and not culled (culling is done at higher-level by ImGui:: functions), if you use this API a lot consider coarse culling your drawn objects.
  */
+
 public final class ImDrawList extends ImGuiStruct {
     public ImDrawList(final long ptr) {
         super(ptr);
@@ -23,7 +29,7 @@ public final class ImDrawList extends ImGuiStruct {
         #define THIS ((ImDrawList*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Flags, you may poke into these to adjust anti-aliasing settings per-primitive.
      */
     public int getFlags() {
@@ -66,7 +72,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->Flags = value;
     */
 
-    /**
+     /**
      * Render-level scissoring.
      * This is passed down to your render function but not used for CPU-side coarse clipping.
      * Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
@@ -787,7 +793,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->AddConvexPolyFilled(points, numPoints, col);
     */
 
-    /**
+     /**
      * Cubic Bezier (4 control points)
      */
     public void addBezierCubic(final ImVec2 p1, final ImVec2 p2, final ImVec2 p3, final ImVec2 p4, final int col, final float thickness) {
@@ -831,7 +837,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->AddBezierCubic(p1, p2, p3, p4, col, thickness, numSegments);
     */
 
-    /**
+     /**
      * Quadratic Bezier (3 control points)
      */
     public void addBezierQuadratic(final ImVec2 p1, final ImVec2 p2, final ImVec2 p3, final int col, final float thickness) {
@@ -1118,7 +1124,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->PathLineToMergeDuplicate(pos);
     */
 
-    /**
+     /**
      * Note: Anti-aliased filling requires points to be in clockwise order.
      */
     public void pathFillConvex(final int col) {
@@ -1187,7 +1193,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->PathArcTo(center, radius, aMin, aMax, numSegments);
     */
 
-    /**
+     /**
      * Use precomputed angles for a 12 steps circle
      */
     public void pathArcToFast(final ImVec2 center, final float radius, final int aMinOf12, final int aMaxOf12) {
@@ -1206,7 +1212,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->PathArcToFast(center, radius, aMinOf12, aMaxOf12);
     */
 
-    /**
+     /**
      * Cubic Bezier (4 control points)
      */
     public void pathBezierCubicCurveTo(final ImVec2 p2, final ImVec2 p3, final ImVec2 p4) {
@@ -1248,7 +1254,7 @@ public final class ImDrawList extends ImGuiStruct {
         THIS->PathBezierCubicCurveTo(p2, p3, p4, numSegments);
     */
 
-    /**
+     /**
      * Quadratic Bezier (3 control points)
      */
     public void pathBezierQuadraticCurveTo(final ImVec2 p2, final ImVec2 p3) {

--- a/imgui-binding/src/generated/java/imgui/ImFont.java
+++ b/imgui-binding/src/generated/java/imgui/ImFont.java
@@ -2,10 +2,17 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
+
+
 /**
  * Font runtime data and rendering
  * ImFontAtlas automatically loads a default embedded font for you when you call GetTexDataAsAlpha8() or GetTexDataAsRGBA32().
  */
+
 public final class ImFont extends ImGuiStructDestroyable {
     public ImFont() {
         super();
@@ -31,7 +38,7 @@ public final class ImFont extends ImGuiStructDestroyable {
 
     // TODO IndexAdvanceX
 
-    /**
+     /**
      * = FallbackGlyph.AdvanceX
      */
     public float getFallbackAdvanceX() {
@@ -53,7 +60,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->FallbackAdvanceX = value;
     */
 
-    /**
+     /**
      * Height of characters/line, set during loading (don't change after loading)
      */
     public float getFontSize() {
@@ -77,7 +84,7 @@ public final class ImFont extends ImGuiStructDestroyable {
 
     // TODO IndexLookup, Glyphs
 
-    private static final ImFontGlyph _GETFALLBACKGLYPH_1 = new ImFontGlyph(0);
+     private static final ImFontGlyph _GETFALLBACKGLYPH_1 = new ImFontGlyph(0);
 
     /**
      * = FindGlyph(FontFallbackChar)
@@ -104,7 +111,7 @@ public final class ImFont extends ImGuiStructDestroyable {
 
     // TODO ContainerAtlas, ConfigData
 
-    /**
+     /**
      * Number of ImFontConfig involved in creating this font.
      * Bigger than 1 when merging multiple font sources into one ImFont.
      */
@@ -128,7 +135,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->ConfigDataCount = value;
     */
 
-    /**
+     /**
      * Character used for ellipsis rendering.
      */
     public short getEllipsisChar() {
@@ -214,7 +221,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->DirtyLookupTables = value;
     */
 
-    /**
+     /**
      * Base font scale, multiplied by the per-window font scale which you can adjust with SetWindowFontScale()
      */
     public float getScale() {
@@ -236,7 +243,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->Scale = value;
     */
 
-    /**
+     /**
      * Ascent: distance from top to bottom of e.g. 'A' [0..FontSize]
      */
     public float getAscent() {
@@ -274,7 +281,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         THIS->Descent = value;
     */
 
-    /**
+     /**
      * Total surface in pixels to get an idea of the font rasterization/texture cost (not exact, we approximate the cost of padding between glyphs)
      */
     public int getMetricsTotalSurface() {
@@ -338,7 +345,7 @@ public final class ImFont extends ImGuiStructDestroyable {
         return env->NewStringUTF(THIS->GetDebugName());
     */
 
-    /**
+     /**
      * 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable.
      * 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.
      */

--- a/imgui-binding/src/generated/java/imgui/ImFontAtlas.java
+++ b/imgui-binding/src/generated/java/imgui/ImFontAtlas.java
@@ -1,6 +1,11 @@
 package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
+
+
+
+
+
 import imgui.type.ImInt;
 
 import java.nio.ByteBuffer;
@@ -25,6 +30,7 @@ import java.nio.ByteOrder;
  * - Even though many functions are suffixed with "TTF", OTF data is supported just as well.
  * - This is an old API and it is currently awkward for those and and various other reasons! We will address them in the future!
  */
+
 public final class ImFontAtlas extends ImGuiStructDestroyable {
     private ByteBuffer alpha8pixels = null;
     private ByteBuffer rgba32pixels = null;
@@ -132,7 +138,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after destruction of the atlas.
      * Set font_cfg.FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed.
      */
@@ -196,7 +202,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * Note: Transfer ownership of 'ttf_data' to ImFontAtlas! Will be deleted after destruction of the atlas.
      * Set font_cfg.FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed.
      */
@@ -260,7 +266,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * 'compressed_font_data' still owned by caller. Compress with binary_to_compressed_c.cpp.
      */
     public ImFont addFontFromMemoryCompressedTTF(final byte[] compressedFontData, final float sizePixels) {
@@ -320,7 +326,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * 'compressed_font_data' still owned by caller. Compress with binary_to_compressed_c.cpp.
      */
     public ImFont addFontFromMemoryCompressedTTF(final byte[] compressedFontData, final int compressedFontSize, final float sizePixels) {
@@ -380,7 +386,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * 'compressed_font_data_base85' still owned by caller. Compress with binary_to_compressed_c.cpp with -base85 parameter.
      */
     public ImFont addFontFromMemoryCompressedBase85TTF(final String compressedFontDataBase85, final float sizePixels, final ImFontConfig fontConfig) {
@@ -410,7 +416,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return _result;
     */
 
-    /**
+     /**
      * Clear input data (all ImFontConfig structures including sizes, TTF data, glyph ranges, etc.) = all the data used to build the texture and fonts.
      */
     public void clearInputData() {
@@ -421,7 +427,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->ClearInputData();
     */
 
-    /**
+     /**
      * Clear output texture data (CPU side). Saves RAM once the texture has been copied to graphics memory.
      */
     public void clearTexData() {
@@ -432,7 +438,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->ClearTexData();
     */
 
-    /**
+     /**
      * Clear output font data (glyphs storage, UV coordinates).
      */
     public void clearFonts() {
@@ -443,7 +449,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->ClearFonts();
     */
 
-    /**
+     /**
      * Clear all input and output.
      */
     public void clear() {
@@ -486,7 +492,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         #endif
     */
 
-    /**
+     /**
      * Build pixels data. This is called automatically for you by the GetTexData*** functions.
      */
     public boolean build() {
@@ -571,7 +577,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return THIS->IsBuilt();
     */
 
-    /**
+     /**
      * User data to refer to the texture once it has been uploaded to user's graphic systems.
      * It is passed back to you during rendering via the ImDrawCmd structure.
      */
@@ -688,7 +694,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         return THIS->AddCustomRectRegular(width, height);
     */
 
-    /**
+     /**
      * Id needs to be {@code <} 0x110000 to register a rectangle to map into a specific font.
      */
     public int addCustomRectFontGlyph(final ImFont imFont, final short id, final int width, final int height, final float advanceX) {
@@ -725,7 +731,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
     // Members
     //-------------------------------------------
 
-    /**
+     /**
      * Build flags (see {@link imgui.flag.ImFontAtlasFlags})
      */
     public int getFlags() {
@@ -770,7 +776,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
 
     // TexID implemented as SetTexID function
 
-    /**
+     /**
      * Texture width desired by user before Build(). Must be a power-of-two.
      * If have many glyphs your graphics API have texture size restrictions you may want to increase texture width to decrease height.
      */
@@ -794,7 +800,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->TexDesiredWidth = value;
     */
 
-    /**
+     /**
      * Padding between glyphs within texture in pixels. Defaults to 1.
      * If your rendering method doesn't rely on bilinear filtering you may set this to 0.
      */
@@ -818,7 +824,7 @@ public final class ImFontAtlas extends ImGuiStructDestroyable {
         THIS->TexGlyphPadding = value;
     */
 
-    /**
+     /**
      * Marked as Locked by ImGui::NewFrame() so attempt to modify the atlas will assert.
      */
     public boolean getLocked() {

--- a/imgui-binding/src/generated/java/imgui/ImFontConfig.java
+++ b/imgui-binding/src/generated/java/imgui/ImFontConfig.java
@@ -2,6 +2,9 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 public final class ImFontConfig extends ImGuiStructDestroyable {
     public ImFontConfig() {
         super();
@@ -44,7 +47,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontData = &fontData[0];
     */
 
-    /**
+     /**
      * TTF/OTF data size
      */
     public int getFontDataSize() {
@@ -66,7 +69,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontDataSize = value;
     */
 
-    /**
+     /**
      * TTF/OTF data ownership taken by the container ImFontAtlas (will delete memory itself).
      */
     public boolean getFontDataOwnedByAtlas() {
@@ -88,7 +91,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontDataOwnedByAtlas = value;
     */
 
-    /**
+     /**
      * Index of font within TTF/OTF file
      */
     public int getFontNo() {
@@ -110,7 +113,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontNo = value;
     */
 
-    /**
+     /**
      * Size in pixels for rasterizer (more or less maps to the resulting font height).
      */
     public float getSizePixels() {
@@ -132,7 +135,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->SizePixels = value;
     */
 
-    /**
+     /**
      * Rasterize at higher quality for sub-pixel positioning.
      * Note the difference between 2 and 3 is minimal so you can reduce this to 2 to save memory.
      * Read https://github.com/nothings/stb/blob/master/tests/oversample/README.md for details.
@@ -158,7 +161,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->OversampleH = value;
     */
 
-    /**
+     /**
      * Rasterize at higher quality for sub-pixel positioning.
      * This is not really useful as we don't use sub-pixel positions on the Y axis.
      */
@@ -182,7 +185,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->OversampleV = value;
     */
 
-    /**
+     /**
      * Align every glyph to pixel boundary. Useful e.g. if you are merging a non-pixel aligned font with the default font.
      * If enabled, you can set OversampleH/V to 1.
      */
@@ -206,7 +209,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->PixelSnapH = value;
     */
 
-    /**
+     /**
      * Extra spacing (in pixels) between glyphs. Only X axis is supported for now.
      */
     public ImVec2 getGlyphExtraSpacing() {
@@ -267,7 +270,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->GlyphExtraSpacing = value;
     */
 
-    /**
+     /**
      * Offset all glyphs from this font input.
      */
     public ImVec2 getGlyphOffset() {
@@ -351,7 +354,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->GlyphRanges = glyphRanges != NULL ? (ImWchar*)&glyphRanges[0] : NULL;
     */
 
-    /**
+     /**
      * Minimum AdvanceX for glyphs, set Min to align font icons, set both Min/Max to enforce mono-space font
      */
     public float getGlyphMinAdvanceX() {
@@ -373,7 +376,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->GlyphMinAdvanceX = value;
     */
 
-    /**
+     /**
      * Maximum AdvanceX for glyphs
      */
     public float getGlyphMaxAdvanceX() {
@@ -395,7 +398,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->GlyphMaxAdvanceX = value;
     */
 
-    /**
+     /**
      * Merge into previous ImFont, so you can combine multiple inputs font into one ImFont (e.g. ASCII font + icons + Japanese glyphs).
      * You may want to use GlyphOffset.y when merge font of different heights.
      */
@@ -419,7 +422,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->MergeMode = value;
     */
 
-    /**
+     /**
      * Settings for custom font builder. THIS IS BUILDER IMPLEMENTATION DEPENDENT. Leave as zero if unsure.
      */
     public int getFontBuilderFlags() {
@@ -462,7 +465,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->FontBuilderFlags = value;
     */
 
-    /**
+     /**
      * Brighten ({@code >}1.0f) or darken ({@code <}1.0f) font output. Brightening small fonts may be a good workaround to make them more readable.
      */
     public float getRasterizerMultiply() {
@@ -484,7 +487,7 @@ public final class ImFontConfig extends ImGuiStructDestroyable {
         THIS->RasterizerMultiply = value;
     */
 
-    /**
+     /**
      * Explicitly specify unicode codepoint of ellipsis character. When fonts are being merged first specified ellipsis will be used.
      */
     public short getEllipsisChar() {

--- a/imgui-binding/src/generated/java/imgui/ImFontGlyph.java
+++ b/imgui-binding/src/generated/java/imgui/ImFontGlyph.java
@@ -2,10 +2,13 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
 /**
  * Hold rendering data for one glyph.
  * (Note: some language parsers may fail to convert the 31+1 bitfield members, in this case maybe drop store a single u32 or we can rework this)
  */
+
 public final class ImFontGlyph extends ImGuiStructDestroyable {
     public ImFontGlyph() {
         super();
@@ -29,7 +32,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImFontGlyph());
     */
 
-    /**
+     /**
      * Flag to indicate glyph is colored and should generally ignore tinting (make it usable with no shift on little-endian as this is used in loops).
      */
     public int getColored() {
@@ -51,7 +54,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Colored = value;
     */
 
-    /**
+     /**
      * Flag to indicate glyph has no visible pixels (e.g. space). Allow early out when rendering.
      */
     public int getVisible() {
@@ -73,7 +76,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Visible = value;
     */
 
-    /**
+     /**
      * 0x0000..0xFFFF
      */
     public int getCodepoint() {
@@ -95,7 +98,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Codepoint = value;
     */
 
-    /**
+     /**
      * Distance to next character (= data from font + ImFontConfig::GlyphExtraSpacing.x baked in)
      */
     public float getAdvanceX() {
@@ -117,7 +120,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->AdvanceX = value;
     */
 
-    /**
+     /**
      * Glyph corners
      */
     public float getX0() {
@@ -139,7 +142,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->X0 = value;
     */
 
-    /**
+     /**
      * Glyph corners
      */
     public float getY0() {
@@ -161,7 +164,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Y0 = value;
     */
 
-    /**
+     /**
      * Glyph corners
      */
     public float getX1() {
@@ -183,7 +186,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->X1 = value;
     */
 
-    /**
+     /**
      * Glyph corners
      */
     public float getY1() {
@@ -205,7 +208,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->Y1 = value;
     */
 
-    /**
+     /**
      * Texture coordinates
      */
     public float getU0() {
@@ -227,7 +230,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->U0 = value;
     */
 
-    /**
+     /**
      * Texture coordinates
      */
     public float getV0() {
@@ -249,7 +252,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->V0 = value;
     */
 
-    /**
+     /**
      * Texture coordinates
      */
     public float getU1() {
@@ -271,7 +274,7 @@ public final class ImFontGlyph extends ImGuiStructDestroyable {
         THIS->U1 = value;
     */
 
-    /**
+     /**
      * Texture coordinates
      */
     public float getV1() {

--- a/imgui-binding/src/generated/java/imgui/ImGui.java
+++ b/imgui-binding/src/generated/java/imgui/ImGui.java
@@ -1,6 +1,12 @@
 package imgui;
 
 import imgui.assertion.ImAssertCallback;
+
+
+
+
+
+
 import imgui.callback.ImGuiInputTextCallback;
 import imgui.internal.ImGuiContext;
 import imgui.type.ImBoolean;
@@ -22,6 +28,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.Properties;
+
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class ImGui {
@@ -213,7 +220,7 @@ public class ImGui {
 
     // Main
 
-    private static final ImGuiIO _GETIO_1 = new ImGuiIO(0);
+     private static final ImGuiIO _GETIO_1 = new ImGuiIO(0);
 
     /**
      * Access the IO structure (mouse/keyboard/gamepad inputs, time, various configuration options/flags).
@@ -227,7 +234,7 @@ public class ImGui {
         return (uintptr_t)&ImGui::GetIO();
     */
 
-    private static final ImGuiStyle _GETSTYLE_1 = new ImGuiStyle(0);
+     private static final ImGuiStyle _GETSTYLE_1 = new ImGuiStyle(0);
 
     /**
      * Access the Style structure (colors, sizes). Always use PushStyleCol(), PushStyleVar() to modify style mid-frame!
@@ -241,7 +248,7 @@ public class ImGui {
         return (uintptr_t)&ImGui::GetStyle();
     */
 
-    /**
+     /**
      * Start a new Dear ImGui frame, you can submit any command from this point until Render()/EndFrame().
      */
     public static void newFrame() {
@@ -252,7 +259,7 @@ public class ImGui {
         ImGui::NewFrame();
     */
 
-    /**
+     /**
      * Ends the Dear ImGui frame. automatically called by Render(). If you don't need to render data (skipping rendering) you may call EndFrame() without
      * Render()... but you'll have wasted CPU already! If you don't need to render, better to not create any windows and not call NewFrame() at all!
      */
@@ -264,7 +271,7 @@ public class ImGui {
         ImGui::EndFrame();
     */
 
-    /**
+     /**
      * Ends the Dear ImGui frame, finalize the draw data. You can then get call GetDrawData().
      */
     public static void render() {
@@ -275,7 +282,7 @@ public class ImGui {
         ImGui::Render();
     */
 
-    private static final ImDrawData _GETDRAWDATA_1 = new ImDrawData(0);
+     private static final ImDrawData _GETDRAWDATA_1 = new ImDrawData(0);
 
     /**
      * Valid after Render() and until the next call to NewFrame(). this is what you have to render.
@@ -291,7 +298,7 @@ public class ImGui {
 
     // Demo, Debug, Information
 
-    /**
+     /**
      * Create Demo window. Demonstrate most ImGui features. Call this to learn about the library!
      */
     public static void showDemoWindow() {
@@ -315,7 +322,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Create Metrics/Debugger window. display Dear ImGui internals: windows, draw commands, various internal state, etc.
      */
     public static void showMetricsWindow() {
@@ -339,7 +346,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Create Debug Log window. display a simplified log of important dear imgui events.
      */
     public static void showDebugLogWindow() {
@@ -363,7 +370,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Create Stack Tool window. hover items with mouse to query information about the source of their unique ID.
      */
     public static void showStackToolWindow() {
@@ -387,7 +394,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Create About window. display Dear ImGui version, credits and build/system information.
      */
     public static void showAboutWindow() {
@@ -411,7 +418,7 @@ public class ImGui {
         if (pOpen != NULL) env->ReleasePrimitiveArrayCritical(obj_pOpen, pOpen, JNI_FALSE);
     */
 
-    /**
+     /**
      * Add style editor block (not a window).
      * You can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else it uses the default style)
      */
@@ -435,7 +442,7 @@ public class ImGui {
         ImGui::ShowStyleEditor(reinterpret_cast<ImGuiStyle*>(ref));
     */
 
-    /**
+     /**
      * Add style selector block (not a window), essentially a combo listing the default styles.
      */
     public static boolean showStyleSelector(final String label) {
@@ -449,7 +456,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Add font selector block (not a window), essentially a combo listing the loaded fonts.
      */
     public static void showFontSelector(final String label) {
@@ -462,7 +469,7 @@ public class ImGui {
         if (label != NULL) env->ReleaseStringUTFChars(obj_label, label);
     */
 
-    /**
+     /**
      * Add basic help/info block (not a window): how to manipulate ImGui as an end-user (mouse/keyboard controls).
      */
     public static void showUserGuide() {
@@ -473,7 +480,7 @@ public class ImGui {
         ImGui::ShowUserGuide();
     */
 
-    /**
+     /**
      * Get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
      */
     public static String getVersion() {
@@ -486,7 +493,7 @@ public class ImGui {
 
     // Styles
 
-    /**
+     /**
      * New, recommended style (default)
      */
     public static void styleColorsDark() {
@@ -508,7 +515,7 @@ public class ImGui {
         ImGui::StyleColorsDark(reinterpret_cast<ImGuiStyle*>(style));
     */
 
-    /**
+     /**
      * Best used with borders and a custom, thicker font
      */
     public static void styleColorsLight() {
@@ -530,7 +537,7 @@ public class ImGui {
         ImGui::StyleColorsLight(reinterpret_cast<ImGuiStyle*>(style));
     */
 
-    /**
+     /**
      * Classic imgui style
      */
     public static void styleColorsClassic() {
@@ -835,7 +842,7 @@ public class ImGui {
         return ImGui::IsWindowCollapsed();
     */
 
-    /**
+     /**
      * Is current window focused? or its root/child, depending on flags. see flags for options.
      */
     public static boolean isWindowFocused() {
@@ -857,7 +864,7 @@ public class ImGui {
         return ImGui::IsWindowFocused(imGuiFocusedFlags);
     */
 
-    /**
+     /**
      * Is current window hovered (and typically: not blocked by a popup/modal)? see flags for options.
      * NB: If you are trying to check whether your mouse should be dispatched to imgui or to your app,
      * you should use the 'io.WantCaptureMouse' boolean for that! Please read the FAQ!
@@ -883,7 +890,7 @@ public class ImGui {
         return ImGui::IsWindowHovered(imGuiHoveredFlags);
     */
 
-    /**
+     /**
      * Get draw list associated to the current window, to append your own drawing primitives
      */
     public static ImDrawList getWindowDrawList() {
@@ -894,7 +901,7 @@ public class ImGui {
         return (uintptr_t)ImGui::GetWindowDrawList();
     */
 
-    /**
+     /**
      * Get DPI scale currently associated to the current window's viewport.
      */
     public static float getWindowDpiScale() {
@@ -905,7 +912,7 @@ public class ImGui {
         return ImGui::GetWindowDpiScale();
     */
 
-    /**
+     /**
      * Get current window position in screen space (note: it is unlikely you need to use this.
      * Consider using current layout pos instead, GetScreenCursorPos())
      */
@@ -951,7 +958,7 @@ public class ImGui {
         return ImGui::GetWindowPos().y;
     */
 
-    /**
+     /**
      * Get current window size (note: it is unlikely you need to use this. Consider using GetScreenCursorPos() and e.g. GetContentRegionAvail() instead)
      */
     public static ImVec2 getWindowSize() {
@@ -993,7 +1000,7 @@ public class ImGui {
         return ImGui::GetWindowSize().y;
     */
 
-    /**
+     /**
      * Get current window width (shortcut for GetWindowSize().x)
      */
     public static float getWindowWidth() {
@@ -1004,7 +1011,7 @@ public class ImGui {
         return ImGui::GetWindowWidth();
     */
 
-    /**
+     /**
      * Get current window height (shortcut for GetWindowSize().y)
      */
     public static float getWindowHeight() {
@@ -1015,7 +1022,7 @@ public class ImGui {
         return ImGui::GetWindowHeight();
     */
 
-    /**
+     /**
      * Get viewport currently associated to the current window.
      */
     public static ImGuiViewport getWindowViewport() {
@@ -1028,7 +1035,7 @@ public class ImGui {
 
     // Prefer using SetNextXXX functions (before Begin) rather that SetXXX functions (after Begin).
 
-    /**
+     /**
      * Set next window position. call before Begin(). use pivot=(0.5f,0.5f) to center on given point, etc.
      */
     public static void setNextWindowPos(final ImVec2 pos) {
@@ -1106,7 +1113,7 @@ public class ImGui {
         ImGui::SetNextWindowPos(pos, ImGuiCond_None, pivot);
     */
 
-    /**
+     /**
      * Set next window size. set axis to 0.0f to force an auto-fit on this axis. call before Begin()
      */
     public static void setNextWindowSize(final ImVec2 size) {
@@ -1144,7 +1151,7 @@ public class ImGui {
         ImGui::SetNextWindowSize(size, cond);
     */
 
-    /**
+     /**
      * Set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. Sizes will be rounded down.
      */
     public static void setNextWindowSizeConstraints(final ImVec2 sizeMin, final ImVec2 sizeMax) {
@@ -1164,7 +1171,7 @@ public class ImGui {
         ImGui::SetNextWindowSizeConstraints(sizeMin, sizeMax);
     */
 
-    /**
+     /**
      * Set next window content size (~ scrollable client area, which enforce the range of scrollbars).
      * Not including window decorations (title bar, menu bar, etc.) nor WindowPadding. set an axis to 0.0f to leave it automatic. call before Begin()
      */
@@ -1185,7 +1192,7 @@ public class ImGui {
         ImGui::SetNextWindowContentSize(size);
     */
 
-    /**
+     /**
      * Set next window collapsed state. call before Begin()
      */
     public static void setNextWindowCollapsed(final boolean collapsed) {
@@ -1207,7 +1214,7 @@ public class ImGui {
         ImGui::SetNextWindowCollapsed(collapsed, cond);
     */
 
-    /**
+     /**
      * Set next window to be focused / top-most. call before Begin()
      */
     public static void setNextWindowFocus() {
@@ -1218,7 +1225,7 @@ public class ImGui {
         ImGui::SetNextWindowFocus();
     */
 
-    /**
+     /**
      * Set next window scrolling value (use {@code < 0.0f} to not affect a given axis).
      */
     public static void setNextWindowScroll(final ImVec2 scroll) {
@@ -1237,7 +1244,7 @@ public class ImGui {
         ImGui::SetNextWindowScroll(scroll);
     */
 
-    /**
+     /**
      * Set next window background color alpha. helper to easily override the Alpha component of ImGuiCol_WindowBg/ChildBg/PopupBg.
      * You may also use ImGuiWindowFlags_NoBackground.
      */
@@ -1249,7 +1256,7 @@ public class ImGui {
         ImGui::SetNextWindowBgAlpha(alpha);
     */
 
-    /**
+     /**
      * Set next window viewport.
      */
     public static void setNextWindowViewport(final int viewportId) {
@@ -1260,7 +1267,7 @@ public class ImGui {
         ImGui::SetNextWindowViewport(viewportId);
     */
 
-    /**
+     /**
      * (not recommended) set current window position - call within Begin()/End().
      * Prefer using SetNextWindowPos(), as this may incur tearing and side-effects.
      */
@@ -1302,7 +1309,7 @@ public class ImGui {
         ImGui::SetWindowPos(pos, cond);
     */
 
-    /**
+     /**
      * (not recommended) set current window size - call within Begin()/End(). set to ImVec2(0,0) to force an auto-fit.
      * Prefer using SetNextWindowSize(), as this may incur tearing and minor side-effects.
      */
@@ -1344,7 +1351,7 @@ public class ImGui {
         ImGui::SetWindowSize(size, cond);
     */
 
-    /**
+     /**
      * (not recommended) set current window collapsed state. prefer using SetNextWindowCollapsed().
      */
     public static void setWindowCollapsed(final boolean collapsed) {
@@ -1366,7 +1373,7 @@ public class ImGui {
         ImGui::SetWindowCollapsed(collapsed, cond);
     */
 
-    /**
+     /**
      * (not recommended) set current window to be focused / top-most. prefer using SetNextWindowFocus().
      */
     public static void setWindowFocus() {
@@ -1377,7 +1384,7 @@ public class ImGui {
         ImGui::SetWindowFocus();
     */
 
-    /**
+     /**
      * Set font scale. Adjust IO.FontGlobalScale if you want to scale all windows.
      * This is an old API! For correct scaling, prefer to reload font + rebuild ImFontAtlas + call style.ScaleAllSizes().
      */
@@ -1389,7 +1396,7 @@ public class ImGui {
         ImGui::SetWindowFontScale(scale);
     */
 
-    /**
+     /**
      * Set named window position.
      */
     public static void setWindowPos(final String name, final ImVec2 pos) {
@@ -1431,7 +1438,7 @@ public class ImGui {
         if (name != NULL) env->ReleaseStringUTFChars(obj_name, name);
     */
 
-    /**
+     /**
      * Set named window size. set axis to 0.0f to force an auto-fit on this axis.
      */
     public static void setWindowSize(final String name, final ImVec2 size) {
@@ -1473,7 +1480,7 @@ public class ImGui {
         if (name != NULL) env->ReleaseStringUTFChars(obj_name, name);
     */
 
-    /**
+     /**
      * Set named window collapsed state
      */
     public static void setWindowCollapsed(final String name, final boolean collapsed) {
@@ -1499,7 +1506,7 @@ public class ImGui {
         if (name != NULL) env->ReleaseStringUTFChars(obj_name, name);
     */
 
-    /**
+     /**
      * Set named window to be focused / top-most. Use NULL to remove focus.
      */
     public static void setWindowFocus(final String name) {
@@ -1516,7 +1523,7 @@ public class ImGui {
     // - Retrieve available space from a given point. GetContentRegionAvail() is frequently useful.
     // - Those functions are bound to be redesigned (they are confusing, incomplete and the Min/Max return values are in local window coordinates which increases confusion)
 
-    /**
+     /**
      * == GetContentRegionMax() - GetCursorPos()
      */
     public static ImVec2 getContentRegionAvail() {
@@ -1558,7 +1565,7 @@ public class ImGui {
         return ImGui::GetContentRegionAvail().y;
     */
 
-    /**
+     /**
      * Current content boundaries (typically window boundaries including scrolling, or current column boundaries), in windows coordinates
      */
     public static ImVec2 getContentRegionMax() {
@@ -1600,7 +1607,7 @@ public class ImGui {
         return ImGui::GetContentRegionMax().y;
     */
 
-    /**
+     /**
      * Content boundaries min for the full window (roughly (0,0)-Scroll), in window coordinates
      */
     public static ImVec2 getWindowContentRegionMin() {
@@ -1642,7 +1649,7 @@ public class ImGui {
         return ImGui::GetWindowContentRegionMin().y;
     */
 
-    /**
+     /**
      * Content boundaries max for the full window (roughly (0,0)+Size-Scroll) where Size can be overridden with SetNextWindowContentSize(), in window coordinates
      */
     public static ImVec2 getWindowContentRegionMax() {
@@ -1688,7 +1695,7 @@ public class ImGui {
     // - Any change of Scroll will be applied at the beginning of next frame in the first call to Begin().
     // - You may instead use SetNextWindowScroll() prior to calling Begin() to avoid this delay, as an alternative to using SetScrollX()/SetScrollY().
 
-    /**
+     /**
      * Get scrolling amount [0 .. GetScrollMaxX()]
      */
     public static float getScrollX() {
@@ -1699,7 +1706,7 @@ public class ImGui {
         return ImGui::GetScrollX();
     */
 
-    /**
+     /**
      * Get scrolling amount [0 .. GetScrollMaxY()]
      */
     public static float getScrollY() {
@@ -1710,7 +1717,7 @@ public class ImGui {
         return ImGui::GetScrollY();
     */
 
-    /**
+     /**
      * Set scrolling amount [0 .. GetScrollMaxX()]
      */
     public static void setScrollX(final float scrollX) {
@@ -1721,7 +1728,7 @@ public class ImGui {
         ImGui::SetScrollX(scrollX);
     */
 
-    /**
+     /**
      * Set scrolling amount [0..GetScrollMaxY()]
      */
     public static void setScrollY(final float scrollY) {
@@ -1732,7 +1739,7 @@ public class ImGui {
         ImGui::SetScrollY(scrollY);
     */
 
-    /**
+     /**
      * Get maximum scrolling amount ~~ ContentSize.x - WindowSize.x - DecorationsSize.x
      */
     public static float getScrollMaxX() {
@@ -1743,7 +1750,7 @@ public class ImGui {
         return ImGui::GetScrollMaxX();
     */
 
-    /**
+     /**
      * Get maximum scrolling amount ~~ ContentSize.y - WindowSize.y - DecorationsSize.y
      */
     public static float getScrollMaxY() {
@@ -1754,7 +1761,7 @@ public class ImGui {
         return ImGui::GetScrollMaxY();
     */
 
-    /**
+     /**
      * Adjust scrolling amount to make current cursor position visible. center_x_ratio=0.0: left, 0.5: center, 1.0: right.
      * When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
      */
@@ -1778,7 +1785,7 @@ public class ImGui {
         ImGui::SetScrollHereX(centerXRatio);
     */
 
-    /**
+     /**
      * Adjust scrolling amount to make current cursor position visible. center_y_ratio=0.0: top, 0.5: center, 1.0: bottom.
      * When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
      */
@@ -1802,7 +1809,7 @@ public class ImGui {
         ImGui::SetScrollHereY(centerYRatio);
     */
 
-    /**
+     /**
      * Adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
      */
     public static void setScrollFromPosX(final float localX) {
@@ -1824,7 +1831,7 @@ public class ImGui {
         ImGui::SetScrollFromPosX(localX, centerXRatio);
     */
 
-    /**
+     /**
      * Adjust scrolling amount to make given position visible. Generally GetCursorStartPos() + offset to compute a valid position.
      */
     public static void setScrollFromPosY(final float localY) {
@@ -1871,7 +1878,7 @@ public class ImGui {
         ImGui::PushStyleColor(imGuiCol, (ImU32)ImColor((int)r, (int)g, (int)b, (int)a));
     */
 
-    /**
+     /**
      * Modify a style color. always use this if you modify the style after NewFrame().
      */
     public static void pushStyleColor(final int imGuiCol, final ImVec4 col) {
@@ -1890,7 +1897,7 @@ public class ImGui {
         ImGui::PushStyleColor(imGuiCol, col);
     */
 
-    /**
+     /**
      * Modify a style color. always use this if you modify the style after NewFrame().
      */
     public static void pushStyleColor(final int imGuiCol, final int col) {
@@ -1917,7 +1924,7 @@ public class ImGui {
         ImGui::PopStyleColor(count);
     */
 
-    /**
+     /**
      * Modify a style float variable. always use this if you modify the style after NewFrame().
      */
     public static void pushStyleVar(final int imGuiStyleVar, final float val) {
@@ -1928,7 +1935,7 @@ public class ImGui {
         ImGui::PushStyleVar(imGuiStyleVar, val);
     */
 
-    /**
+     /**
      * Modify a style ImVec2 variable. always use this if you modify the style after NewFrame().
      */
     public static void pushStyleVar(final int imGuiStyleVar, final ImVec2 val) {
@@ -1963,7 +1970,7 @@ public class ImGui {
         ImGui::PopStyleVar(count);
     */
 
-    /**
+     /**
      * Tab stop enable. Allow focusing using TAB/Shift-TAB, enabled by default but you can disable it for certain widgets
      */
     public static void pushTabStop(final boolean tabStop) {
@@ -1982,7 +1989,7 @@ public class ImGui {
         ImGui::PopTabStop();
     */
 
-    /**
+     /**
      * In 'repeat' mode, Button*() functions return repeated true in a typematic manner (using io.KeyRepeatDelay/io.KeyRepeatRate setting).
      * Note that you can call IsItemActive() after any Button() to tell if the button is held in the current frame.
      */
@@ -2004,7 +2011,7 @@ public class ImGui {
 
     // Parameters stacks (current window)
 
-    /**
+     /**
      * Push width of items for common large "item+label" widgets. {@code > 0.0f}: width in pixels,
      * {@code <0.0f} align xx pixels to the right of window (so -1.0f always align width to the right side).
      */
@@ -2024,7 +2031,7 @@ public class ImGui {
         ImGui::PopItemWidth();
     */
 
-    /**
+     /**
      * Set width of the _next_ common large "item+label" widget. {@code > 0.0f}: width in pixels,
      * {@code <0.0f} align xx pixels to the right of window (so -1.0f always align width to the right side)
      */
@@ -2036,7 +2043,7 @@ public class ImGui {
         ImGui::SetNextItemWidth(itemWidth);
     */
 
-    /**
+     /**
      * Width of item given pushed settings and current cursor position. NOT necessarily the width of last item unlike most 'Item' functions.
      */
     public static float calcItemWidth() {
@@ -2047,7 +2054,7 @@ public class ImGui {
         return ImGui::CalcItemWidth();
     */
 
-    /**
+     /**
      * Push Word-wrapping positions for Text*() commands. {@code < 0.0f}: no wrapping; 0.0f: wrap to end of window (or column); {@code > 0.0f}: wrap at
      * 'wrap_posX' position in window local space
      */
@@ -2082,7 +2089,7 @@ public class ImGui {
     // Style read access
     // - Use the ShowStyleEditor() function to interactively see/edit the colors.
 
-    private static final ImFont _GETFONT_1 = new ImFont(0);
+     private static final ImFont _GETFONT_1 = new ImFont(0);
 
     /**
      * Get current font.
@@ -2096,7 +2103,7 @@ public class ImGui {
         return (uintptr_t)ImGui::GetFont();
     */
 
-    /**
+     /**
      * Get current font size (= height in pixels) of current font with current scale applied
      */
     public static int getFontSize() {
@@ -2107,7 +2114,7 @@ public class ImGui {
         return ImGui::GetFontSize();
     */
 
-    /**
+     /**
      * Get UV coordinate for a while pixel, useful to draw custom shapes via the ImDrawList API
      */
     public static ImVec2 getFontTexUvWhitePixel() {
@@ -2149,7 +2156,7 @@ public class ImGui {
         return ImGui::GetFontTexUvWhitePixel().y;
     */
 
-    /**
+     /**
      * Retrieve given style color with style alpha applied and optional extra alpha multiplier, packed as a 32-bit value suitable for ImDrawList.
      */
     public static int getColorU32(final int idx) {
@@ -2171,7 +2178,7 @@ public class ImGui {
         return ImGui::GetColorU32(static_cast<ImGuiCol>(idx), alphaMul);
     */
 
-    /**
+     /**
      * Retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList.
      */
     public static int getColorU32(final ImVec4 col) {
@@ -2191,7 +2198,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Retrieve given color with style alpha applied, packed as a 32-bit value suitable for ImDrawList.
      */
     public static int getColorU32i(final int col) {
@@ -2202,7 +2209,7 @@ public class ImGui {
         return ImGui::GetColorU32(static_cast<ImU32>(col));
     */
 
-    /**
+     /**
      * Retrieve style color as stored in ImGuiStyle structure. use to feed back into PushStyleColor(),
      * otherwise use GetColorU32() to get style color with style alpha baked in.
      */
@@ -2280,7 +2287,7 @@ public class ImGui {
     //    Window-local coordinates:   SameLine(), GetCursorPos(), SetCursorPos(), GetCursorStartPos(), GetContentRegionMax(), GetWindowContentRegion*(), PushTextWrapPos()
     //    Absolute coordinate:        GetCursorScreenPos(), SetCursorScreenPos(), all ImDrawList:: functions.
 
-    /**
+     /**
      * Separator, generally horizontal. inside a menu bar or in horizontal layout mode, this becomes a vertical separator.
      */
     public static void separator() {
@@ -2291,7 +2298,7 @@ public class ImGui {
         ImGui::Separator();
     */
 
-    /**
+     /**
      * Call between widgets or groups to layout them horizontally. X position given in window coordinates.
      */
     public static void sameLine() {
@@ -2324,7 +2331,7 @@ public class ImGui {
         ImGui::SameLine(offsetFromStartX, spacing);
     */
 
-    /**
+     /**
      * Undo a SameLine() or force a new line when in a horizontal-layout context.
      */
     public static void newLine() {
@@ -2335,7 +2342,7 @@ public class ImGui {
         ImGui::NewLine();
     */
 
-    /**
+     /**
      * Add vertical spacing.
      */
     public static void spacing() {
@@ -2346,7 +2353,7 @@ public class ImGui {
         ImGui::Spacing();
     */
 
-    /**
+     /**
      * Add a dummy item of given size. unlike InvisibleButton(), Dummy() won't take the mouse click or be navigable into.
      */
     public static void dummy(final ImVec2 size) {
@@ -2365,7 +2372,7 @@ public class ImGui {
         ImGui::Dummy(size);
     */
 
-    /**
+     /**
      * Move content position toward the right, by indent_w, or style.IndentSpacing if indent_w {@code <= 0}.
      */
     public static void indent() {
@@ -2387,7 +2394,7 @@ public class ImGui {
         ImGui::Indent(indentW);
     */
 
-    /**
+     /**
      * Move content position back to the left, by indent_w, or style.IndentSpacing if indent_w {@code <= 0}.
      */
     public static void unindent() {
@@ -2409,7 +2416,7 @@ public class ImGui {
         ImGui::Unindent(indentW);
     */
 
-    /**
+     /**
      * Lock horizontal starting position
      */
     public static void beginGroup() {
@@ -2420,7 +2427,7 @@ public class ImGui {
         ImGui::BeginGroup();
     */
 
-    /**
+     /**
      * Unlock horizontal starting position + capture the whole group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
      */
     public static void endGroup() {
@@ -2436,7 +2443,7 @@ public class ImGui {
     //  are using the main, absolute coordinate system.
     //  GetWindowPos() + GetCursorPos() == GetCursorScreenPos() etc.)
 
-    /**
+     /**
      * Cursor position in window coordinates (relative to window position)
      */
     public static ImVec2 getCursorPos() {
@@ -2478,7 +2485,7 @@ public class ImGui {
         return ImGui::GetCursorPos().y;
     */
 
-    /**
+     /**
      * Cursor position in window coordinates (relative to window position)
      */
     public static void setCursorPos(final ImVec2 pos) {
@@ -2497,7 +2504,7 @@ public class ImGui {
         ImGui::SetCursorPos(pos);
     */
 
-    /**
+     /**
      * Cursor position in window coordinates (relative to window position)
      */
     public static void setCursorPosX(final float x) {
@@ -2508,7 +2515,7 @@ public class ImGui {
         ImGui::SetCursorPosX(x);
     */
 
-    /**
+     /**
      * Cursor position in window coordinates (relative to window position)
      */
     public static void setCursorPosY(final float y) {
@@ -2519,7 +2526,7 @@ public class ImGui {
         ImGui::SetCursorPosY(y);
     */
 
-    /**
+     /**
      * Initial cursor position in window coordinates
      */
     public static ImVec2 getCursorStartPos() {
@@ -2561,7 +2568,7 @@ public class ImGui {
         return ImGui::GetCursorStartPos().y;
     */
 
-    /**
+     /**
      * Cursor position in absolute coordinates (useful to work with ImDrawList API).
      * Generally top-left == GetMainViewport().Pos == (0,0) in single viewport mode,
      * and bottom-right == GetMainViewport().Pos+Size == io.DisplaySize in single-viewport mode.
@@ -2611,7 +2618,7 @@ public class ImGui {
         return ImGui::GetCursorScreenPos().y;
     */
 
-    /**
+     /**
      * Cursor position in absolute coordinates.
      */
     public static void setCursorScreenPos(final ImVec2 pos) {
@@ -2630,7 +2637,7 @@ public class ImGui {
         ImGui::SetCursorScreenPos(pos);
     */
 
-    /**
+     /**
      * Vertically align upcoming text baseline to FramePadding.y so that it will align properly to regularly framed items (call if you have text on a line before a framed item)
      */
     public static void alignTextToFramePadding() {
@@ -2641,7 +2648,7 @@ public class ImGui {
         ImGui::AlignTextToFramePadding();
     */
 
-    /**
+     /**
      * ~ FontSize
      */
     public static float getTextLineHeight() {
@@ -2652,7 +2659,7 @@ public class ImGui {
         return ImGui::GetTextLineHeight();
     */
 
-    /**
+     /**
      * ~ FontSize + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of text)
      */
     public static float getTextLineHeightWithSpacing() {
@@ -2663,7 +2670,7 @@ public class ImGui {
         return ImGui::GetTextLineHeightWithSpacing();
     */
 
-    /**
+     /**
      * ~ FontSize + style.FramePadding.y * 2
      */
     public static float getFrameHeight() {
@@ -2674,7 +2681,7 @@ public class ImGui {
         return ImGui::GetFrameHeight();
     */
 
-    /**
+     /**
      * ~ FontSize + style.FramePadding.y * 2 + style.ItemSpacing.y (distance in pixels between 2 consecutive lines of framed widgets)
      */
     public static float getFrameHeightWithSpacing() {
@@ -2697,7 +2704,7 @@ public class ImGui {
     // - In this header file we use the "label"/"name" terminology to denote a string that will be displayed + used as an ID,
     //   whereas "str_id" denote a string that is only used as an ID and not normally displayed.
 
-    /**
+     /**
      * Push string into the ID stack (will hash string).
      */
     public static void pushID(final String strId) {
@@ -2710,7 +2717,7 @@ public class ImGui {
         if (strId != NULL) env->ReleaseStringUTFChars(obj_strId, strId);
     */
 
-    /**
+     /**
      * Push string into the ID stack (will hash string).
      */
     public static void pushID(final String strIdBegin, final String strIdEnd) {
@@ -2725,7 +2732,7 @@ public class ImGui {
         if (strIdEnd != NULL) env->ReleaseStringUTFChars(obj_strIdEnd, strIdEnd);
     */
 
-    /**
+     /**
      * Push pointer into the ID stack (will hash pointer).
      */
     public static void pushID(final long ptrId) {
@@ -2736,7 +2743,7 @@ public class ImGui {
         ImGui::PushID((void*)ptrId);
     */
 
-    /**
+     /**
      * Push integer into the ID stack (will hash integer).
      */
     public static void pushID(final int intId) {
@@ -2747,7 +2754,7 @@ public class ImGui {
         ImGui::PushID(intId);
     */
 
-    /**
+     /**
      * Pop from the ID stack.
      */
     public static void popID() {
@@ -2758,7 +2765,7 @@ public class ImGui {
         ImGui::PopID();
     */
 
-    /**
+     /**
      * Calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
      */
     public static int getID(final String strId) {
@@ -2772,7 +2779,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
      */
     public static int getID(final String strIdBegin, final String strIdEnd) {
@@ -2788,7 +2795,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
      */
     public static int getID(final long ptrId) {
@@ -2801,7 +2808,7 @@ public class ImGui {
 
     // Widgets: Text
 
-    /**
+     /**
      * Raw text without formatting. Roughly equivalent to Text("%s", text) but:
      * A) doesn't require null terminated string if 'textEnd' is specified,
      * B) it's faster, no memory copy is done, no buffer size limits, recommended for long chunks of text.
@@ -2833,7 +2840,7 @@ public class ImGui {
         if (textEnd != NULL) env->ReleaseStringUTFChars(obj_textEnd, textEnd);
     */
 
-    /**
+     /**
      * Formatted text
      */
     public static void text(final String text) {
@@ -2846,7 +2853,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Shortcut for PushStyleColor(ImGuiCol_Text, col); Text(fmt, ...); PopStyleColor();
      */
     public static void textColored(final ImVec4 col, final String text) {
@@ -2881,7 +2888,7 @@ public class ImGui {
         ImGui::TextColored(ImColor(col), text, NULL);
     */
 
-    /**
+     /**
      * Shortcut for PushStyleColor(ImGuiCol_Text, style.Colors[ImGuiCol_TextDisabled]); Text(fmt, ...); PopStyleColor();
      */
     public static void textDisabled(final String text) {
@@ -2894,7 +2901,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Shortcut for PushTextWrapPos(0.0f); Text(fmt, ...); PopTextWrapPos();.
      * Note that this won't work on an auto-resizing window if there's no other widgets to extend the window width,
      * yoy may need to set a size using SetNextWindowSize().
@@ -2909,7 +2916,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Display text+label aligned the same way as value+label widgets
      */
     public static void labelText(final String label, final String text) {
@@ -2924,7 +2931,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Shortcut for Bullet()+Text()
      */
     public static void bulletText(final String text) {
@@ -2937,7 +2944,7 @@ public class ImGui {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Currently: formatted text with an horizontal line
      */
     public static void separatorText(final String label) {
@@ -2954,7 +2961,7 @@ public class ImGui {
     // - Most widgets return true when the value has been changed or when pressed/selected
     // - You may also use one of the many IsItemXXX functions (e.g. IsItemActive, IsItemHovered, etc.) to query widget state.
 
-    /**
+     /**
      * Button
      */
     public static boolean button(final String label) {
@@ -2990,7 +2997,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Button with FramePadding=(0,0) to easily embed within text
      */
     public static boolean smallButton(final String label) {
@@ -3004,7 +3011,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
      */
     public static boolean invisibleButton(final String strId, final ImVec2 size) {
@@ -3048,7 +3055,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Square button with an arrow shape
      */
     public static boolean arrowButton(final String strId, final int dir) {
@@ -3097,7 +3104,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Use with e.g. if (RadioButton("one", my_value==1)) { my_value = 1; }
      */
     public static boolean radioButton(final String label, final boolean active) {
@@ -3111,7 +3118,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Shortcut to handle the above pattern when value is an integer
      */
     public static boolean radioButton(final String label, final ImInt v, final int vButton) {
@@ -3173,7 +3180,7 @@ public class ImGui {
         if (overlay != NULL) env->ReleaseStringUTFChars(obj_overlay, overlay);
     */
 
-    /**
+     /**
      * Draw a small circle + keep the cursor on the same line. advance cursor x position by GetTreeNodeToLabelSpacing(), same distance that TreeNode() uses
      */
     public static void bullet() {
@@ -3383,7 +3390,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndCombo() if BeginCombo() returns true!
      */
     public static void endCombo() {
@@ -3440,7 +3447,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Separate items with \0 within a string, end item-list with \0\0. e.g. "One\0Two\0Three\0"
      */
     public static boolean combo(final String label, final ImInt currentItem, final String itemsSeparatedByZeros) {
@@ -3489,7 +3496,7 @@ public class ImGui {
     // - Legacy: Pre-1.78 there are DragXXX() function signatures that take a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument.
     //   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361
 
-    /**
+     /**
      * If {@code vMin >= vMax} we have no bound
      */
     public static boolean dragFloat(final String label, final float[] v) {
@@ -3990,7 +3997,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * If {@code vMin >= vMax} we have no bound
      */
     public static boolean dragInt(final String label, final int[] v) {
@@ -5333,7 +5340,7 @@ public class ImGui {
     // - Legacy: Pre-1.78 there are SliderXXX() function signatures that take a final `float power=1.0f' argument instead of the `ImGuiSliderFlags flags=0' argument.
     //   If you get a warning converting a float to ImGuiSliderFlags, read https://github.com/ocornut/imgui/issues/3361
 
-    /**
+     /**
      * Adjust format to decorate the value with a prefix or a suffix for in-slider labels or unit display.
      */
     public static boolean sliderFloat(final String label, final float[] v, final float vMin, final float vMax) {
@@ -8949,7 +8956,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Display a colored square/button, hover for details, return true when pressed.
      */
     public static boolean colorButton(final String descId, final ImVec4 col) {
@@ -9039,7 +9046,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Display a colored square/button, hover for details, return true when pressed.
      *
      * @deprecated use {@link #colorButton(String, ImVec4)} or {@link #colorButton(String, float, float, float, float)} instead
@@ -9137,7 +9144,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Initialize current options (generally on application startup) if you want to select a default format,
      * picker type, etc. User will be able to change many settings, unless you pass the _NoOptions flag to your calls.
      */
@@ -9163,7 +9170,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Helper variation to easily decorelate the id from the displayed string.
      * Read the FAQ about why and how to use ID. to align arbitrary text at the same level as a TreeNode() you can use Bullet().
      */
@@ -9237,7 +9244,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * ~ Indent()+PushId(). Already called by TreeNode() when returning true, but you can call TreePush/TreePop yourself if desired.
      */
     public static void treePush(final String strId) {
@@ -9250,7 +9257,7 @@ public class ImGui {
         if (strId != NULL) env->ReleaseStringUTFChars(obj_strId, strId);
     */
 
-    /**
+     /**
      * ~ Indent()+PushId(). Already called by TreeNode() when returning true, but you can call TreePush/TreePop yourself if desired.
      */
     public static void treePush(final long ptrId) {
@@ -9261,7 +9268,7 @@ public class ImGui {
         ImGui::TreePush((void*)ptrId);
     */
 
-    /**
+     /**
      * ~ Unindent()+PopId()
      */
     public static void treePop() {
@@ -9272,7 +9279,7 @@ public class ImGui {
         ImGui::TreePop();
     */
 
-    /**
+     /**
      * Horizontal distance preceding label when using TreeNode*() or Bullet() == (g.FontSize + style.FramePadding.x*2) for a regular unframed TreeNode
      */
     public static float getTreeNodeToLabelSpacing() {
@@ -9283,7 +9290,7 @@ public class ImGui {
         return ImGui::GetTreeNodeToLabelSpacing();
     */
 
-    /**
+     /**
      * If returning 'true' the header is open. doesn't indent nor push on ID stack. user doesn't have to call TreePop().
      */
     public static boolean collapsingHeader(final String label) {
@@ -9311,7 +9318,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * When 'p_visible != NULL': if '*p_visible==true' display an additional small close button on upper right of the header which will set the bool
      * to false when clicked, if '*p_visible==false' don't display the header.
      */
@@ -9345,7 +9352,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Set next TreeNode/CollapsingHeader open state.
      */
     public static void setNextItemOpen(final boolean isOpen) {
@@ -9537,7 +9544,7 @@ public class ImGui {
     // - Choose frame width:   size.x > 0.0f: custom  /  size.{@code x {@code <} 0.0f} or -FLT_MIN: right-align   /  size.x = 0.0f (default): use current ItemWidth
     // - Choose frame height:  size.y > 0.0f: custom  /  size.y {@code < 0.0f} or -FLT_MIN: bottom-align  /  size.y = 0.0f (default): arbitrary default height which can fit ~7 items
 
-    /**
+     /**
      * Open a framed scrolling region.
      */
     public static boolean beginListBox(final String label) {
@@ -9573,7 +9580,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndListBox() if BeginListBox() returned true!
      */
     public static void endListBox() {
@@ -9993,7 +10000,7 @@ public class ImGui {
     // - Use BeginMainMenuBar() to create a menu bar at the top of the screen and append to it.
     // - Use BeginMenu() to create a menu. You can call BeginMenu() multiple time with the same identifier to append more items to it.
 
-    /**
+     /**
      * Append to menu-bar of current window (requires ImGuiWindowFlags_MenuBar flag set on parent window).
      */
     public static boolean beginMenuBar() {
@@ -10004,7 +10011,7 @@ public class ImGui {
         return ImGui::BeginMenuBar();
     */
 
-    /**
+     /**
      * Only call EndMenuBar() if BeginMenuBar() returns true!
      */
     public static void endMenuBar() {
@@ -10015,7 +10022,7 @@ public class ImGui {
         ImGui::EndMenuBar();
     */
 
-    /**
+     /**
      * Create and append to a full screen menu-bar.
      */
     public static boolean beginMainMenuBar() {
@@ -10026,7 +10033,7 @@ public class ImGui {
         return ImGui::BeginMainMenuBar();
     */
 
-    /**
+     /**
      * Only call EndMainMenuBar() if BeginMainMenuBar() returns true!
      */
     public static void endMainMenuBar() {
@@ -10037,7 +10044,7 @@ public class ImGui {
         ImGui::EndMainMenuBar();
     */
 
-    /**
+     /**
      * Create a sub-menu entry. only call EndMenu() if this returns true!
      */
     public static boolean beginMenu(final String label) {
@@ -10065,7 +10072,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndMenu() if BeginMenu() returns true!
      */
     public static void endMenu() {
@@ -10076,7 +10083,7 @@ public class ImGui {
         ImGui::EndMenu();
     */
 
-    /**
+     /**
      * Return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
      */
     public static boolean menuItem(final String label) {
@@ -10118,7 +10125,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Return true when activated. shortcuts are displayed for convenience but not processed by ImGui at the moment
      */
     public static boolean menuItem(final String label, final String shortcut) {
@@ -10166,7 +10173,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Return true when activated + toggle (*pSelected) if pSelected != NULL
      */
     public static boolean menuItem(final String label, final String shortcut, final ImBoolean pSelected) {
@@ -10206,7 +10213,7 @@ public class ImGui {
     // - Tooltips are windows following the mouse. They do not take focus away.
     // - A tooltip window can contain items of any types. SetTooltip() is a shortcut for the 'if (BeginTooltip()) { Text(...); EndTooltip(); }' idiom.
 
-    /**
+     /**
      * Begin/append a tooltip window.
      */
     public static void beginTooltip() {
@@ -10217,7 +10224,7 @@ public class ImGui {
         ImGui::BeginTooltip();
     */
 
-    /**
+     /**
      * Only call EndTooltip() if BeginTooltip()/BeginItemTooltip() returns true!
      */
     public static void endTooltip() {
@@ -10228,7 +10235,7 @@ public class ImGui {
         ImGui::EndTooltip();
     */
 
-    /**
+     /**
      * Set a text-only tooltip. Often used after a ImGui::IsItemHovered() check. Override any previous call to SetTooltip().
      */
     public static void setTooltip(final String text) {
@@ -10246,7 +10253,7 @@ public class ImGui {
     // - SetItemTooltip() is a shortcut for the 'if (IsItemHovered(ImGuiHoveredFlags_Tooltip)) { SetTooltip(...); }' idiom.
     // - Where 'ImGuiHoveredFlags_Tooltip' itself is a shortcut to use 'style.HoverFlagsForTooltipMouse' or 'style.HoverFlagsForTooltipNav' depending on active input type. For mouse it defaults to 'ImGuiHoveredFlags_Stationary | ImGuiHoveredFlags_DelayShort'.
 
-    /**
+     /**
      * Begin/append a tooltip window if preceding item was hovered.
      */
     public static boolean beginItemTooltip() {
@@ -10257,7 +10264,7 @@ public class ImGui {
         return ImGui::BeginItemTooltip();
     */
 
-    /**
+     /**
      * Set a text-only tooltip if preceeding item was hovered. override any previous call to SetTooltip().
      */
     public static void setItemTooltip(final String text) {
@@ -10282,7 +10289,7 @@ public class ImGui {
     //  - BeginPopup(): query popup state, if open start appending into the window. Call EndPopup() afterwards. ImGuiWindowFlags are forwarded to the window.
     //  - BeginPopupModal(): block every interaction behind the window, cannot be closed by user, add a dimming background, has a title bar.
 
-    /**
+     /**
      * Return true if the popup is open, and you can start outputting to it.
      */
     public static boolean beginPopup(final String strId) {
@@ -10310,7 +10317,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Return true if the popup is open, and you can start outputting to it.
      */
     public static boolean beginPopupModal(final String name) {
@@ -10370,7 +10377,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndPopup() if BeginPopupXXX() returns true!
      */
     public static void endPopup() {
@@ -10388,7 +10395,7 @@ public class ImGui {
     //  - CloseCurrentPopup() is called by default by Selectable()/MenuItem() when activated (FIXME: need some options).
     //  - Use ImGuiPopupFlags_NoOpenOverExistingPopup to avoid opening a popup if there's already one at the same level. This is equivalent to e.g. testing for !IsAnyPopupOpen() prior to OpenPopup().
 
-    /**
+     /**
      * Call to mark popup as open (don't call every frame!).
      */
     public static void openPopup(final String strId) {
@@ -10414,7 +10421,7 @@ public class ImGui {
         if (strId != NULL) env->ReleaseStringUTFChars(obj_strId, strId);
     */
 
-    /**
+     /**
      * Id overload to facilitate calling from nested stacks.
      */
     public static void openPopup(final int id) {
@@ -10436,7 +10443,7 @@ public class ImGui {
         ImGui::OpenPopup((ImGuiID)id, imGuiPopupFlags);
     */
 
-    /**
+     /**
      * Helper to open popup when clicked on last item. return true when just opened. (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
      */
     public static void openPopupOnItemClick() {
@@ -10484,7 +10491,7 @@ public class ImGui {
         ImGui::OpenPopupOnItemClick(NULL, imGuiPopupFlags);
     */
 
-    /**
+     /**
      * Manually close the popup we have begin-ed into.
      */
     public static void closeCurrentPopup() {
@@ -10501,7 +10508,7 @@ public class ImGui {
     //  - IMPORTANT: Notice that BeginPopupContextXXX takes ImGuiPopupFlags just like OpenPopup() and unlike BeginPopup(). For full consistency, we may add ImGuiWindowFlags to the BeginPopupContextXXX functions in the future.
     //  - IMPORTANT: we exceptionally default their flags to 1 (== ImGuiPopupFlags_MouseButtonRight) for backward compatibility with older API taking 'int mouse_button = 1' parameter, so if you add other flags remember to re-add the ImGuiPopupFlags_MouseButtonRight.
 
-    /**
+     /**
      * Open+begin popup when clicked on last item. if you can pass a NULL str_id only if the previous item had an id.
      * If you want to use that on a non-interactive item such as Text() you need to pass in an explicit ID here. read comments in .cpp!
      */
@@ -10555,7 +10562,7 @@ public class ImGui {
         return ImGui::BeginPopupContextItem(NULL, imGuiPopupFlags);
     */
 
-    /**
+     /**
      * Open+begin popup when clicked on current window.
      */
     public static boolean beginPopupContextWindow() {
@@ -10605,7 +10612,7 @@ public class ImGui {
         return ImGui::BeginPopupContextWindow(NULL, imGuiPopupFlags);
     */
 
-    /**
+     /**
      * Open+begin popup when clicked in void (where there are no windows).
      */
     public static boolean beginPopupContextVoid() {
@@ -10660,7 +10667,7 @@ public class ImGui {
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId: return true if any popup is open at the current BeginPopup() level of the popup stack.
     //  - IsPopupOpen() with ImGuiPopupFlags_AnyPopupId + ImGuiPopupFlags_AnyPopupLevel: return true if any popup is open.
 
-    /**
+     /**
      * Return true if the popup is open.
      */
     public static boolean isPopupOpen(final String strId) {
@@ -10804,7 +10811,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndTable() if BeginTable() returns true!
      */
     public static void endTable() {
@@ -10815,7 +10822,7 @@ public class ImGui {
         ImGui::EndTable();
     */
 
-    /**
+     /**
      * Append into the first cell of a new row.
      */
     public static void tableNextRow() {
@@ -10859,7 +10866,7 @@ public class ImGui {
         ImGui::TableNextRow(0, minRowHeight);
     */
 
-    /**
+     /**
      * Append into the next column (or first column of next row if currently in last column). Return true when column is visible.
      */
     public static boolean tableNextColumn() {
@@ -10870,7 +10877,7 @@ public class ImGui {
         return ImGui::TableNextColumn();
     */
 
-    /**
+     /**
      * Append into the specified column. Return true when column is visible.
      */
     public static boolean tableSetColumnIndex(final int columnN) {
@@ -10950,7 +10957,7 @@ public class ImGui {
         if (label != NULL) env->ReleaseStringUTFChars(obj_label, label);
     */
 
-    /**
+     /**
      * Lock columns/rows so they stay visible when scrolled.
      */
     public static void tableSetupScrollFreeze(final int cols, final int rows) {
@@ -10961,7 +10968,7 @@ public class ImGui {
         ImGui::TableSetupScrollFreeze(cols, rows);
     */
 
-    /**
+     /**
      * Submit all headers cells based on data provided to TableSetupColumn() + submit context menu
      */
     public static void tableHeadersRow() {
@@ -10972,7 +10979,7 @@ public class ImGui {
         ImGui::TableHeadersRow();
     */
 
-    /**
+     /**
      * Submit one header cell manually (rarely used)
      */
     public static void tableHeader(final String label) {
@@ -10992,7 +10999,7 @@ public class ImGui {
     //   else you may wastefully sort your data every frame!
     // - Functions args 'int column_n' treat the default value of -1 as the same as passing the current column index.
 
-    /**
+     /**
      * Get latest sort specs for the table (NULL if not sorting).
      * Lifetime: don't hold on this pointer over multiple frames or past any subsequent call to BeginTable().
      */
@@ -11007,7 +11014,7 @@ public class ImGui {
     // Tables: Miscellaneous functions
     // - Functions args 'int column_n' treat the default value of -1 as the same as passing the current column index.
 
-    /**
+     /**
      * Return number of columns (value passed to BeginTable).
      */
     public static int tableGetColumnCount() {
@@ -11018,7 +11025,7 @@ public class ImGui {
         return ImGui::TableGetColumnCount();
     */
 
-    /**
+     /**
      * Return current column index.
      */
     public static int tableGetColumnIndex() {
@@ -11029,7 +11036,7 @@ public class ImGui {
         return ImGui::TableGetColumnIndex();
     */
 
-    /**
+     /**
      * Return current row index.
      */
     public static int tableGetRowIndex() {
@@ -11040,7 +11047,7 @@ public class ImGui {
         return ImGui::TableGetRowIndex();
     */
 
-    /**
+     /**
      * Return "" if column didn't have a name declared by TableSetupColumn(). Pass -1 to use current column.
      */
     public static String tableGetColumnName() {
@@ -11062,7 +11069,7 @@ public class ImGui {
         return env->NewStringUTF(ImGui::TableGetColumnName(columnN));
     */
 
-    /**
+     /**
      * Return column flags, so you can query their Enabled/Visible/Sorted/Hovered status flags. Pass -1 to use current column.
      */
     public static int tableGetColumnFlags() {
@@ -11084,7 +11091,7 @@ public class ImGui {
         return ImGui::TableGetColumnFlags(columnN);
     */
 
-    /**
+     /**
      * change user accessible enabled/disabled state of a column. Set to false to hide the column.
      * User can use the context menu to change this themselves (right-click in headers, or right-click in columns body with ImGuiTableFlags_ContextMenuInBody)
      */
@@ -11096,7 +11103,7 @@ public class ImGui {
         ImGui::TableSetColumnEnabled(columnN, value);
     */
 
-    /**
+     /**
      * Change the color of a cell, row, or column. See ImGuiTableBgTarget_ flags for details.
      */
     public static void tableSetBgColor(final int imGuiTableBgTarget, final int color) {
@@ -11184,7 +11191,7 @@ public class ImGui {
         ImGui::Columns(count, NULL, border);
     */
 
-    /**
+     /**
      * Next column, defaults to current row or next row if the current row is finished
      */
     public static void nextColumn() {
@@ -11195,7 +11202,7 @@ public class ImGui {
         ImGui::NextColumn();
     */
 
-    /**
+     /**
      * Get current column index
      */
     public static int getColumnIndex() {
@@ -11206,7 +11213,7 @@ public class ImGui {
         return ImGui::GetColumnIndex();
     */
 
-    /**
+     /**
      * Get column width (in pixels). pass -1 to use current column
      */
     public static float getColumnWidth() {
@@ -11228,7 +11235,7 @@ public class ImGui {
         return ImGui::GetColumnWidth(columnIndex);
     */
 
-    /**
+     /**
      * Set column width (in pixels). pass -1 to use current column
      */
     public static void setColumnWidth(final int columnIndex, final float width) {
@@ -11239,7 +11246,7 @@ public class ImGui {
         ImGui::SetColumnWidth(columnIndex, width);
     */
 
-    /**
+     /**
      * Get position of column line (in pixels, from the left side of the contents region). pass -1 to use current column, otherwise 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
      */
     public static float getColumnOffset() {
@@ -11261,7 +11268,7 @@ public class ImGui {
         return ImGui::GetColumnOffset(columnIndex);
     */
 
-    /**
+     /**
      * Set position of column line (in pixels, from the left side of the contents region). pass -1 to use current column
      */
     public static void setColumnOffset(final int columnIndex, final float offsetX) {
@@ -11283,7 +11290,7 @@ public class ImGui {
     // Tab Bars, Tabs
     // - Note: Tabs are automatically created by the docking system (when in 'docking' branch). Use this to create tab bars/tabs yourself.
 
-    /**
+     /**
      * Create and append into a TabBar
      */
     public static boolean beginTabBar(final String strId) {
@@ -11311,7 +11318,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndTabBar() if BeginTabBar() returns true!
      */
     public static void endTabBar() {
@@ -11322,7 +11329,7 @@ public class ImGui {
         ImGui::EndTabBar();
     */
 
-    /**
+     /**
      * Create a Tab. Returns true if the Tab is selected.
      */
     public static boolean beginTabItem(final String label) {
@@ -11382,7 +11389,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndTabItem() if BeginTabItem() returns true!
      */
     public static void endTabItem() {
@@ -11393,7 +11400,7 @@ public class ImGui {
         ImGui::EndTabItem();
     */
 
-    /**
+     /**
      * Create a Tab behaving like a button. return true when clicked. cannot be selected in the tab bar.
      */
     public static boolean tabItemButton(final String label) {
@@ -11421,7 +11428,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars).
      * For tab-bar: call after BeginTabBar() and before Tab submissions. Otherwise call with a window name.
      */
@@ -11569,7 +11576,7 @@ public class ImGui {
         return ImGui::DockSpaceOverViewport(reinterpret_cast<ImGuiViewport*>(viewport), 0, reinterpret_cast<ImGuiWindowClass*>(windowClass));
     */
 
-    /**
+     /**
      * Set next window dock id
      */
     public static void setNextWindowDockID(final int dockId) {
@@ -11591,7 +11598,7 @@ public class ImGui {
         ImGui::SetNextWindowDockID(dockId, imGuiCond);
     */
 
-    /**
+     /**
      * set next window class (rare/advanced uses: provide hints to the platform backend via altered viewport flags and parent/child info)
      */
     public static void setNextWindowClass(final ImGuiWindowClass windowClass) {
@@ -11610,7 +11617,7 @@ public class ImGui {
         return ImGui::GetWindowDockID();
     */
 
-    /**
+     /**
      * Is current window docked into another window?
      */
     public static boolean isWindowDocked() {
@@ -11624,7 +11631,7 @@ public class ImGui {
     // Logging/Capture
     // - All text output from the interface can be captured into tty/file/clipboard. By default, tree nodes are automatically opened during logging.
 
-    /**
+     /**
      * Start logging to tty (stdout)
      */
     public static void logToTTY() {
@@ -11646,7 +11653,7 @@ public class ImGui {
         ImGui::LogToTTY(autoOpenDepth);
     */
 
-    /**
+     /**
      * Start logging to file
      */
     public static void logToFile() {
@@ -11694,7 +11701,7 @@ public class ImGui {
         if (filename != NULL) env->ReleaseStringUTFChars(obj_filename, filename);
     */
 
-    /**
+     /**
      * Start logging to OS clipboard
      */
     public static void logToClipboard() {
@@ -11716,7 +11723,7 @@ public class ImGui {
         ImGui::LogToClipboard(autoOpenDepth);
     */
 
-    /**
+     /**
      * Stop logging (close file, etc.)
      */
     public static void logFinish() {
@@ -11727,7 +11734,7 @@ public class ImGui {
         ImGui::LogFinish();
     */
 
-    /**
+     /**
      * Helper to display buttons for logging to tty/file/clipboard
      */
     public static void logButtons() {
@@ -11738,7 +11745,7 @@ public class ImGui {
         ImGui::LogButtons();
     */
 
-    /**
+     /**
      * Pass text data straight to log (without being displayed)
      */
     public static void logText(final String text) {
@@ -11754,7 +11761,7 @@ public class ImGui {
     // Drag and Drop
     // - If you stop calling BeginDragDropSource() the payload is preserved however it won't have a preview tooltip (we currently display a fallback "..." tooltip as replacement)
 
-    /**
+     /**
      * Call when the current item is active. If this return true, you can call SetDragDropPayload() + EndDragDropSource()
      */
     public static boolean beginDragDropSource() {
@@ -11822,7 +11829,7 @@ public class ImGui {
         return ImGui::SetDragDropPayload(dataType, &data[0], sz, imGuiCond);
     */
 
-    /**
+     /**
      * Only call EndDragDropSource() if BeginDragDropSource() returns true!
      */
     public static void endDragDropSource() {
@@ -11833,7 +11840,7 @@ public class ImGui {
         ImGui::EndDragDropSource();
     */
 
-    /**
+     /**
      * Call after submitting an item that may receive a payload. If this returns true, you can call AcceptDragDropPayload() + EndDragDropTarget()
      */
     public static boolean beginDragDropTarget() {
@@ -11899,7 +11906,7 @@ public class ImGui {
         return ImGui::AcceptDragDropPayload(dataType, imGuiDragDropFlags) != NULL;
     */
 
-    /**
+     /**
      * Only call EndDragDropTarget() if BeginDragDropTarget() returns true!
      */
     public static void endDragDropTarget() {
@@ -11955,7 +11962,7 @@ public class ImGui {
         return payload != NULL && payload->IsDataType(dataType);
     */
 
-    /**
+     /**
      * Disable all user interactions and dim items visuals (applying style.DisabledAlpha over current colors)
      * BeginDisabled(false) essentially does nothing useful but is provided to facilitate use of boolean expressions.
      * If you can avoid calling BeginDisabled(False)/EndDisabled() best to avoid it.
@@ -12017,7 +12024,7 @@ public class ImGui {
     // Focus, Activation
     // - Prefer using "SetItemDefaultFocus()" over "if (IsWindowAppearing()) SetScrollHereY()" when applicable to signify "this is the default item"
 
-    /**
+     /**
      * Make last item the default focused item of a window.
      */
     public static void setItemDefaultFocus() {
@@ -12028,7 +12035,7 @@ public class ImGui {
         ImGui::SetItemDefaultFocus();
     */
 
-    /**
+     /**
      * Focus keyboard on the next widget. Use positive 'offset' to access sub components of a multiple component widget. Use -1 to access previous widget.
      */
     public static void setKeyboardFocusHere() {
@@ -12052,7 +12059,7 @@ public class ImGui {
 
     // Overlapping mode
 
-    /**
+     /**
      * Allow next item to be overlapped by a subsequent item.
      * Useful with invisible buttons, selectable, treenode covering an area where subsequent items may need to be added.
      * Note that both Selectable() and TreeNode() have dedicated flags doing this.
@@ -12069,7 +12076,7 @@ public class ImGui {
     // - Most of the functions are referring to the last/previous item we submitted.
     // - See Demo Window under "Widgets->Querying Status" for an interactive visualization of most of those functions.
 
-    /**
+     /**
      * Is the last item hovered? (and usable, aka not blocked by a popup, etc.). See ImGuiHoveredFlags for more options.
      */
     public static boolean isItemHovered() {
@@ -12091,7 +12098,7 @@ public class ImGui {
         return ImGui::IsItemHovered(imGuiHoveredFlags);
     */
 
-    /**
+     /**
      * Is the last item active? (e.g. button being held, text field being edited.
      * This will continuously return true while holding mouse button on an item.
      * Items that don't interact will always return false)
@@ -12104,7 +12111,7 @@ public class ImGui {
         return ImGui::IsItemActive();
     */
 
-    /**
+     /**
      * Is the last item focused for keyboard/gamepad navigation?
      */
     public static boolean isItemFocused() {
@@ -12115,7 +12122,7 @@ public class ImGui {
         return ImGui::IsItemFocused();
     */
 
-    /**
+     /**
      * Is the last item hovered and mouse clicked on? (**)  == {@code IsMouseClicked(mouseButton) && IsItemHovered()}
      * Important. (**) this is NOT equivalent to the behavior of e.g. Button(). Read comments in function definition.
      */
@@ -12139,7 +12146,7 @@ public class ImGui {
         return ImGui::IsItemClicked(mouseButton);
     */
 
-    /**
+     /**
      * Is the last item visible? (items may be out of sight because of clipping/scrolling)
      */
     public static boolean isItemVisible() {
@@ -12150,7 +12157,7 @@ public class ImGui {
         return ImGui::IsItemVisible();
     */
 
-    /**
+     /**
      * Did the last item modify its underlying value this frame? or was pressed? This is generally the same as the "bool" return value of many widgets.
      */
     public static boolean isItemEdited() {
@@ -12161,7 +12168,7 @@ public class ImGui {
         return ImGui::IsItemEdited();
     */
 
-    /**
+     /**
      * Was the last item just made active (item was previously inactive).
      */
     public static boolean isItemActivated() {
@@ -12172,7 +12179,7 @@ public class ImGui {
         return ImGui::IsItemActivated();
     */
 
-    /**
+     /**
      * Was the last item just made inactive (item was previously active). Useful for Undo/Redo patterns with widgets that require continuous editing.
      */
     public static boolean isItemDeactivated() {
@@ -12183,7 +12190,7 @@ public class ImGui {
         return ImGui::IsItemDeactivated();
     */
 
-    /**
+     /**
      * Was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved).
      * Useful for Undo/Redo patterns with widgets that require continuous editing.
      * Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
@@ -12196,7 +12203,7 @@ public class ImGui {
         return ImGui::IsItemDeactivatedAfterEdit();
     */
 
-    /**
+     /**
      * Was the last item open state toggled? set by TreeNode().
      */
     public static boolean isItemToggledOpen() {
@@ -12207,7 +12214,7 @@ public class ImGui {
         return ImGui::IsItemToggledOpen();
     */
 
-    /**
+     /**
      * Is any item hovered?
      */
     public static boolean isAnyItemHovered() {
@@ -12218,7 +12225,7 @@ public class ImGui {
         return ImGui::IsAnyItemHovered();
     */
 
-    /**
+     /**
      * Is any item active?
      */
     public static boolean isAnyItemActive() {
@@ -12228,7 +12235,7 @@ public class ImGui {
     private static native boolean nIsAnyItemActive(); /*
         return ImGui::IsAnyItemActive();
     */
-    /**
+     /**
      * Is any item focused?
      */
     public static boolean isAnyItemFocused() {
@@ -12239,7 +12246,7 @@ public class ImGui {
         return ImGui::IsAnyItemFocused();
     */
 
-    /**
+     /**
      * Get ID of last item (~~ often same ImGui::GetID(label) beforehand)
      */
     public static int getItemID() {
@@ -12250,7 +12257,7 @@ public class ImGui {
         return ImGui::GetItemID();
     */
 
-    /**
+     /**
      * Get upper-left bounding rectangle of the last item (screen space)
      */
     public static ImVec2 getItemRectMin() {
@@ -12292,7 +12299,7 @@ public class ImGui {
         return ImGui::GetItemRectMin().y;
     */
 
-    /**
+     /**
      * Get lower-right bounding rectangle of the last item (screen space)
      */
     public static ImVec2 getItemRectMax() {
@@ -12334,7 +12341,7 @@ public class ImGui {
         return ImGui::GetItemRectMax().y;
     */
 
-    /**
+     /**
      * Get size of last item
      */
     public static ImVec2 getItemRectSize() {
@@ -12381,7 +12388,7 @@ public class ImGui {
     // - In 'docking' branch with multi-viewport enabled, we extend this concept to have multiple active viewports.
     // - In the future we will extend this concept further to also represent Platform Monitor and support a "no main platform window" operation mode.
 
-    private static final ImGuiViewport _GETMAINVIEWPORT_1 = new ImGuiViewport(0);
+     private static final ImGuiViewport _GETMAINVIEWPORT_1 = new ImGuiViewport(0);
 
     /**
      * Return primary/default viewport.
@@ -12397,7 +12404,7 @@ public class ImGui {
 
     // Background/Foreground Draw Lists
 
-    /**
+     /**
      * Get background draw list for the viewport associated to the current window.
      * This draw list will be the first rendering one. Useful to quickly draw shapes/text behind dear imgui contents.
      */
@@ -12421,7 +12428,7 @@ public class ImGui {
         return (uintptr_t)ImGui::GetBackgroundDrawList(reinterpret_cast<ImGuiViewport*>(viewport));
     */
 
-    /**
+     /**
      * Get foreground draw list for the viewport associated to the current window.
      * This draw list will be the last rendered one. Useful to quickly draw shapes/text over dear imgui contents.
      */
@@ -12447,7 +12454,7 @@ public class ImGui {
 
     // Miscellaneous Utilities
 
-    /**
+     /**
      * Test if rectangle (of given size, starting from cursor position) is visible / not clipped.
      */
     public static boolean isRectVisible(final ImVec2 size) {
@@ -12467,7 +12474,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Test if rectangle (in screen space) is visible / not clipped. to perform coarse clipping on user's side.
      */
     public static boolean isRectVisible(final ImVec2 rectMin, final ImVec2 rectMax) {
@@ -12488,7 +12495,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Get global imgui time. incremented by io.DeltaTime every frame.
      */
     public static double getTime() {
@@ -12499,7 +12506,7 @@ public class ImGui {
         return ImGui::GetTime();
     */
 
-    /**
+     /**
      * Get global imgui frame count. incremented by 1 every frame.
      */
     public static int getFrameCount() {
@@ -12514,7 +12521,7 @@ public class ImGui {
 
     // TODO GetDrawListSharedData
 
-    /**
+     /**
      * Get a string corresponding to the enum value (for display, saving, etc.).
      */
     public static String getStyleColorName(final int imGuiColIdx) {
@@ -12525,7 +12532,7 @@ public class ImGui {
         return env->NewStringUTF(ImGui::GetStyleColorName(imGuiColIdx));
     */
 
-    /**
+     /**
      * Replace current window storage with our own (if you want to manipulate it yourself, typically clear subsection of it).
      */
     public static void setStateStorage(final ImGuiStorage storage) {
@@ -12544,7 +12551,7 @@ public class ImGui {
         return (uintptr_t)ImGui::GetStateStorage();
     */
 
-    /**
+     /**
      * Helper to create a child window / scrolling region that looks like a normal widget frame
      */
     public static boolean beginChildFrame(final int id, final ImVec2 size) {
@@ -12584,7 +12591,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Always call EndChildFrame() regardless of BeginChildFrame() return values (which indicates a collapsed/clipped window)
      */
     public static void endChildFrame() {
@@ -12833,7 +12840,7 @@ public class ImGui {
     //  - without IMGUI_DISABLE_OBSOLETE_KEYIO (legacy support): you can still use your legacy native/user indices (< 512) according to how your backend/engine stored them in io.KeysDown[], but need to cast them to ImGuiKey.
     //  - with    IMGUI_DISABLE_OBSOLETE_KEYIO (this is the way forward): any use of ImGuiKey will assert with key < 512. GetKeyIndex() is pass-through and therefore deprecated (gone if IMGUI_DISABLE_OBSOLETE_KEYIO is defined).
 
-    /**
+     /**
      * Map ImGuiKey_* values into user's key index. == io.KeyMap[key]
      */
     @Deprecated
@@ -12845,7 +12852,7 @@ public class ImGui {
         return ImGui::GetKeyIndex(static_cast<ImGuiKey>(key));
     */
 
-    /**
+     /**
      * Is key being held. == io.KeysDown[user_key_index].
      */
     public static boolean isKeyDown(final int key) {
@@ -12856,7 +12863,7 @@ public class ImGui {
         return ImGui::IsKeyDown(static_cast<ImGuiKey>(key));
     */
 
-    /**
+     /**
      * Was key pressed (went from !Down to Down)? if repeat=true, uses io.KeyRepeatDelay / KeyRepeatRate
      */
     public static boolean isKeyPressed(final int key) {
@@ -12878,7 +12885,7 @@ public class ImGui {
         return ImGui::IsKeyPressed(static_cast<ImGuiKey>(key), repeat);
     */
 
-    /**
+     /**
      * Was key released (went from Down to !Down)
      */
     public static boolean isKeyReleased(final int key) {
@@ -12889,7 +12896,7 @@ public class ImGui {
         return ImGui::IsKeyReleased(static_cast<ImGuiKey>(key));
     */
 
-    /**
+     /**
      * Uses provided repeat rate/delay.
      * Return a count, most often 0 or 1 but might be {@code >1} if RepeatRate is small enough that {@code DeltaTime > RepeatRate}
      */
@@ -12901,7 +12908,7 @@ public class ImGui {
         return ImGui::GetKeyPressedAmount(static_cast<ImGuiKey>(key), repeatDelay, rate);
     */
 
-    /**
+     /**
      * [DEBUG] returns English name of the key. Those names a provided for debugging purpose and are not meant to be saved persistently not compared.
      */
     public static String getKeyName(final int key) {
@@ -12912,7 +12919,7 @@ public class ImGui {
         return env->NewStringUTF(ImGui::GetKeyName(static_cast<ImGuiKey>(key)));
     */
 
-    /**
+     /**
      * Override io.WantCaptureKeyboard flag next frame (said flag is left for your application to handle,
      * typically when true it instructs your app to ignore inputs). e.g. force capture keyboard when your widget is being hovered.
      * This is equivalent to setting "io.WantCaptureKeyboard = want_capture_keyboard"; after the next NewFrame() call.
@@ -12930,7 +12937,7 @@ public class ImGui {
     // - You can also use regular integer: it is forever guaranteed that 0=Left, 1=Right, 2=Middle.
     // - Dragging operations are only reported after mouse has moved a certain distance away from the initial clicking position (see 'lock_threshold' and 'io.MouseDraggingThreshold')
 
-    /**
+     /**
      * Is mouse button held (0=left, 1=right, 2=middle)
      */
     public static boolean isMouseDown(final int button) {
@@ -12941,7 +12948,7 @@ public class ImGui {
         return ImGui::IsMouseDown(button);
     */
 
-    /**
+     /**
      * Did mouse button clicked (went from !Down to Down) (0=left, 1=right, 2=middle)
      */
     public static boolean isMouseClicked(final int button) {
@@ -12963,7 +12970,7 @@ public class ImGui {
         return ImGui::IsMouseClicked(button, repeat);
     */
 
-    /**
+     /**
      * Did mouse button released (went from Down to !Down)
      */
     public static boolean isMouseReleased(final int button) {
@@ -12974,7 +12981,7 @@ public class ImGui {
         return ImGui::IsMouseReleased(button);
     */
 
-    /**
+     /**
      * did mouse button double-clicked? (note that a double-click will also report IsMouseClicked() == true).
      */
     public static boolean isMouseDoubleClicked(final int button) {
@@ -12985,7 +12992,7 @@ public class ImGui {
         return ImGui::IsMouseDoubleClicked(button);
     */
 
-    /**
+     /**
      * Return the number of successive mouse-clicks at the time where a click happen (otherwise 0).
      */
     public static int getMouseClickedCount(final int button) {
@@ -12996,7 +13003,7 @@ public class ImGui {
         return ImGui::GetMouseClickedCount(button);
     */
 
-    /**
+     /**
      * Is mouse hovering given bounding rect (in screen space). clipped by current clipping settings, but disregarding of other consideration of focus/window ordering/popup-block.
      */
     public static boolean isMouseHoveringRect(final ImVec2 rMin, final ImVec2 rMax) {
@@ -13038,7 +13045,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * By convention we use (-FLT_MAX,-FLT_MAX) to denote that there is no mouse
      */
     public static boolean isMousePosValid() {
@@ -13069,7 +13076,7 @@ public class ImGui {
         return _result;
     */
 
-    /**
+     /**
      * Is any mouse button held
      */
     public static boolean isAnyMouseDown() {
@@ -13080,7 +13087,7 @@ public class ImGui {
         return ImGui::IsAnyMouseDown();
     */
 
-    /**
+     /**
      * Shortcut to ImGui::GetIO().MousePos provided by user, to be consistent with other calls
      */
     public static ImVec2 getMousePos() {
@@ -13122,7 +13129,7 @@ public class ImGui {
         return ImGui::GetMousePos().y;
     */
 
-    /**
+     /**
      * Retrieve backup of mouse position at the time of opening popup we have BeginPopup() into
      */
     public static ImVec2 getMousePosOnOpeningCurrentPopup() {
@@ -13164,7 +13171,7 @@ public class ImGui {
         return ImGui::GetMousePosOnOpeningCurrentPopup().y;
     */
 
-    /**
+     /**
      * Is mouse dragging. if lockThreshold {@code < -1.0f} uses io.MouseDraggingThreshold
      */
     public static boolean isMouseDragging(final int button) {
@@ -13186,7 +13193,7 @@ public class ImGui {
         return ImGui::IsMouseDragging(button, lockThreshold);
     */
 
-    /**
+     /**
      * Return the delta from the initial clicking position while the mouse button is pressed or was just released.
      * This is locked and return 0.0f until the mouse moves past a distance threshold at least once. If lockThreshold {@code < -1.0f} uses io.MouseDraggingThreshold.
      */
@@ -13340,7 +13347,7 @@ public class ImGui {
         ImGui::ResetMouseDragDelta(button);
     */
 
-    /**
+     /**
      * Get desired mouse cursor shape. Important: reset in ImGui::NewFrame(), this is updated during the frame. valid before Render().
      * If you use software rendering by setting io.MouseDrawCursor ImGui will render those for you
      */
@@ -13352,7 +13359,7 @@ public class ImGui {
         return ImGui::GetMouseCursor();
     */
 
-    /**
+     /**
      * Set desired mouse cursor shape
      */
     public static void setMouseCursor(final int type) {
@@ -13363,7 +13370,7 @@ public class ImGui {
         ImGui::SetMouseCursor(type);
     */
 
-    /**
+     /**
      * Override io.WantCaptureMouse flag next frame (said flag is left for your application to handle,
      * typical when true it instucts your app to ignore inputs).
      * This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse;" after the next NewFrame() call.
@@ -13401,7 +13408,7 @@ public class ImGui {
     // - The disk functions are automatically called if io.IniFilename != NULL (default is "imgui.ini").
     // - Set io.IniFilename to NULL to load/save manually. Read io.WantSaveIniSettings description about handling .ini saving manually.
 
-    /**
+     /**
      * Call after CreateContext() and before the first call to NewFrame(). NewFrame() automatically calls LoadIniSettingsFromDisk(io.IniFilename).
      */
     public static void loadIniSettingsFromDisk(final String iniFilename) {
@@ -13414,7 +13421,7 @@ public class ImGui {
         if (iniFilename != NULL) env->ReleaseStringUTFChars(obj_iniFilename, iniFilename);
     */
 
-    /**
+     /**
      * Call after CreateContext() and before the first call to NewFrame() to provide .ini data from your own data source.
      */
     public static void loadIniSettingsFromMemory(final String iniData) {
@@ -13440,7 +13447,7 @@ public class ImGui {
         if (iniData != NULL) env->ReleaseStringUTFChars(obj_iniData, iniData);
     */
 
-    /**
+     /**
      * This is automatically called (if io.IniFilename is not empty) a few seconds after any modification that should be reflected in the .ini file (and also by DestroyContext).
      */
     public static void saveIniSettingsToDisk(final String iniFilename) {
@@ -13453,7 +13460,7 @@ public class ImGui {
         if (iniFilename != NULL) env->ReleaseStringUTFChars(obj_iniFilename, iniFilename);
     */
 
-    /**
+     /**
      * Return a zero-terminated string with the .ini data which you can save by your own mean.
      * Call when io.WantSaveIniSettings is set, then save data by your own mean and clear io.WantSaveIniSettings.
      */
@@ -13504,7 +13511,7 @@ public class ImGui {
     // Read comments around the ImGuiPlatformIO structure for more details.
     // Note: You may use GetWindowViewport() to get the current viewport of the current window.
 
-    private static final ImGuiPlatformIO _GETPLATFORMIO_1 = new ImGuiPlatformIO(0);
+     private static final ImGuiPlatformIO _GETPLATFORMIO_1 = new ImGuiPlatformIO(0);
 
     /**
      * Platform/renderer functions, for backend to setup + viewports list.
@@ -13518,7 +13525,7 @@ public class ImGui {
         return (uintptr_t)&ImGui::GetPlatformIO();
     */
 
-    /**
+     /**
      * Call in main loop. Will call CreateWindow/ResizeWindow/etc. Platform functions for each secondary viewport, and DestroyWindow for each inactive viewport.
      */
     public static void updatePlatformWindows() {
@@ -13529,7 +13536,7 @@ public class ImGui {
         ImGui::UpdatePlatformWindows();
     */
 
-    /**
+     /**
      * Call in main loop. will call RenderWindow/SwapBuffers platform functions for each secondary viewport which doesn't have the ImGuiViewportFlags_Minimized flag set.
      * May be reimplemented by user for custom rendering needs.
      */
@@ -13541,7 +13548,7 @@ public class ImGui {
         ImGui::RenderPlatformWindowsDefault();
     */
 
-    /**
+     /**
      * Call DestroyWindow platform functions for all viewports.
      * Call from backend Shutdown() if you need to close platform windows before imgui shutdown.
      * Otherwise will be called by DestroyContext().
@@ -13554,7 +13561,7 @@ public class ImGui {
         ImGui::DestroyPlatformWindows();
     */
 
-    /**
+     /**
      * This is a helper for backends.
      */
     public static ImGuiViewport findViewportByID(final int imGuiID) {
@@ -13565,7 +13572,7 @@ public class ImGui {
         return (uintptr_t)ImGui::FindViewportByID(imGuiID);
     */
 
-    /**
+     /**
      * This is a helper for backends. The type platform_handle is decided by the backend (e.g. HWND, MyWindow*, GLFWwindow* etc.)
      */
     public static ImGuiViewport findViewportByPlatformHandle(final long platformHandle) {
@@ -13574,5 +13581,245 @@ public class ImGui {
 
     private static native long nFindViewportByPlatformHandle(long platformHandle); /*
         return (uintptr_t)ImGui::FindViewportByPlatformHandle((void*)platformHandle);
+    */
+
+    public static void beginHorizontal(final String str_id) {
+        nBeginHorizontal(str_id);
+    }
+
+    public static void beginHorizontal(final String str_id, final ImVec2 size) {
+        nBeginHorizontal(str_id, size.x, size.y);
+    }
+
+    public static void beginHorizontal(final String str_id, final float sizeX, final float sizeY) {
+        nBeginHorizontal(str_id, sizeX, sizeY);
+    }
+
+    public static void beginHorizontal(final String str_id, final ImVec2 size, final float align) {
+        nBeginHorizontal(str_id, size.x, size.y, align);
+    }
+
+    public static void beginHorizontal(final String str_id, final float sizeX, final float sizeY, final float align) {
+        nBeginHorizontal(str_id, sizeX, sizeY, align);
+    }
+
+    public static void beginHorizontal(final String str_id, final float align) {
+        nBeginHorizontal(str_id, align);
+    }
+
+    private static native void nBeginHorizontal(String str_id); /*MANUAL
+        auto str_id = obj_str_id == NULL ? NULL : (char*)env->GetStringUTFChars(obj_str_id, JNI_FALSE);
+        ImGui::BeginHorizontal(str_id);
+        if (str_id != NULL) env->ReleaseStringUTFChars(obj_str_id, str_id);
+    */
+
+    private static native void nBeginHorizontal(String str_id, float sizeX, float sizeY); /*MANUAL
+        auto str_id = obj_str_id == NULL ? NULL : (char*)env->GetStringUTFChars(obj_str_id, JNI_FALSE);
+        ImVec2 size = ImVec2(sizeX, sizeY);
+        ImGui::BeginHorizontal(str_id, size);
+        if (str_id != NULL) env->ReleaseStringUTFChars(obj_str_id, str_id);
+    */
+
+    private static native void nBeginHorizontal(String str_id, float sizeX, float sizeY, float align); /*MANUAL
+        auto str_id = obj_str_id == NULL ? NULL : (char*)env->GetStringUTFChars(obj_str_id, JNI_FALSE);
+        ImVec2 size = ImVec2(sizeX, sizeY);
+        ImGui::BeginHorizontal(str_id, size, align);
+        if (str_id != NULL) env->ReleaseStringUTFChars(obj_str_id, str_id);
+    */
+
+    private static native void nBeginHorizontal(String str_id, float align); /*MANUAL
+        auto str_id = obj_str_id == NULL ? NULL : (char*)env->GetStringUTFChars(obj_str_id, JNI_FALSE);
+        ImGui::BeginHorizontal(str_id, ImVec2(0,0), align);
+        if (str_id != NULL) env->ReleaseStringUTFChars(obj_str_id, str_id);
+    */
+
+    public static void beginHorizontal(final int id) {
+        nBeginHorizontal(id);
+    }
+
+    public static void beginHorizontal(final int id, final ImVec2 size) {
+        nBeginHorizontal(id, size.x, size.y);
+    }
+
+    public static void beginHorizontal(final int id, final float sizeX, final float sizeY) {
+        nBeginHorizontal(id, sizeX, sizeY);
+    }
+
+    public static void beginHorizontal(final int id, final ImVec2 size, final float align) {
+        nBeginHorizontal(id, size.x, size.y, align);
+    }
+
+    public static void beginHorizontal(final int id, final float sizeX, final float sizeY, final float align) {
+        nBeginHorizontal(id, sizeX, sizeY, align);
+    }
+
+    public static void beginHorizontal(final int id, final float align) {
+        nBeginHorizontal(id, align);
+    }
+
+    private static native void nBeginHorizontal(int id); /*
+        ImGui::BeginHorizontal(id);
+    */
+
+    private static native void nBeginHorizontal(int id, float sizeX, float sizeY); /*MANUAL
+        ImVec2 size = ImVec2(sizeX, sizeY);
+        ImGui::BeginHorizontal(id, size);
+    */
+
+    private static native void nBeginHorizontal(int id, float sizeX, float sizeY, float align); /*MANUAL
+        ImVec2 size = ImVec2(sizeX, sizeY);
+        ImGui::BeginHorizontal(id, size, align);
+    */
+
+    private static native void nBeginHorizontal(int id, float align); /*
+        ImGui::BeginHorizontal(id, ImVec2(0,0), align);
+    */
+
+    public static void endHorizontal() {
+        nEndHorizontal();
+    }
+
+    private static native void nEndHorizontal(); /*
+        ImGui::EndHorizontal();
+    */
+
+    public static void beginVertical(final String str_id) {
+        nBeginVertical(str_id);
+    }
+
+    public static void beginVertical(final String str_id, final ImVec2 size) {
+        nBeginVertical(str_id, size.x, size.y);
+    }
+
+    public static void beginVertical(final String str_id, final float sizeX, final float sizeY) {
+        nBeginVertical(str_id, sizeX, sizeY);
+    }
+
+    public static void beginVertical(final String str_id, final ImVec2 size, final float align) {
+        nBeginVertical(str_id, size.x, size.y, align);
+    }
+
+    public static void beginVertical(final String str_id, final float sizeX, final float sizeY, final float align) {
+        nBeginVertical(str_id, sizeX, sizeY, align);
+    }
+
+    public static void beginVertical(final String str_id, final float align) {
+        nBeginVertical(str_id, align);
+    }
+
+    private static native void nBeginVertical(String str_id); /*MANUAL
+        auto str_id = obj_str_id == NULL ? NULL : (char*)env->GetStringUTFChars(obj_str_id, JNI_FALSE);
+        ImGui::BeginVertical(str_id);
+        if (str_id != NULL) env->ReleaseStringUTFChars(obj_str_id, str_id);
+    */
+
+    private static native void nBeginVertical(String str_id, float sizeX, float sizeY); /*MANUAL
+        auto str_id = obj_str_id == NULL ? NULL : (char*)env->GetStringUTFChars(obj_str_id, JNI_FALSE);
+        ImVec2 size = ImVec2(sizeX, sizeY);
+        ImGui::BeginVertical(str_id, size);
+        if (str_id != NULL) env->ReleaseStringUTFChars(obj_str_id, str_id);
+    */
+
+    private static native void nBeginVertical(String str_id, float sizeX, float sizeY, float align); /*MANUAL
+        auto str_id = obj_str_id == NULL ? NULL : (char*)env->GetStringUTFChars(obj_str_id, JNI_FALSE);
+        ImVec2 size = ImVec2(sizeX, sizeY);
+        ImGui::BeginVertical(str_id, size, align);
+        if (str_id != NULL) env->ReleaseStringUTFChars(obj_str_id, str_id);
+    */
+
+    private static native void nBeginVertical(String str_id, float align); /*MANUAL
+        auto str_id = obj_str_id == NULL ? NULL : (char*)env->GetStringUTFChars(obj_str_id, JNI_FALSE);
+        ImGui::BeginVertical(str_id, ImVec2(0,0), align);
+        if (str_id != NULL) env->ReleaseStringUTFChars(obj_str_id, str_id);
+    */
+
+    public static void beginVertical(final int id) {
+        nBeginVertical(id);
+    }
+
+    public static void beginVertical(final int id, final ImVec2 size) {
+        nBeginVertical(id, size.x, size.y);
+    }
+
+    public static void beginVertical(final int id, final float sizeX, final float sizeY) {
+        nBeginVertical(id, sizeX, sizeY);
+    }
+
+    public static void beginVertical(final int id, final ImVec2 size, final float align) {
+        nBeginVertical(id, size.x, size.y, align);
+    }
+
+    public static void beginVertical(final int id, final float sizeX, final float sizeY, final float align) {
+        nBeginVertical(id, sizeX, sizeY, align);
+    }
+
+    public static void beginVertical(final int id, final float align) {
+        nBeginVertical(id, align);
+    }
+
+    private static native void nBeginVertical(int id); /*
+        ImGui::BeginVertical(id);
+    */
+
+    private static native void nBeginVertical(int id, float sizeX, float sizeY); /*MANUAL
+        ImVec2 size = ImVec2(sizeX, sizeY);
+        ImGui::BeginVertical(id, size);
+    */
+
+    private static native void nBeginVertical(int id, float sizeX, float sizeY, float align); /*MANUAL
+        ImVec2 size = ImVec2(sizeX, sizeY);
+        ImGui::BeginVertical(id, size, align);
+    */
+
+    private static native void nBeginVertical(int id, float align); /*
+        ImGui::BeginVertical(id, ImVec2(0,0), align);
+    */
+
+    public static void endVertical() {
+        nEndVertical();
+    }
+
+    private static native void nEndVertical(); /*
+        ImGui::EndVertical();
+    */
+
+    public static void spring() {
+        nSpring();
+    }
+
+    public static void spring(final float weight) {
+        nSpring(weight);
+    }
+
+    public static void spring(final float weight, final float spacing) {
+        nSpring(weight, spacing);
+    }
+
+    private static native void nSpring(); /*
+        ImGui::Spring();
+    */
+
+    private static native void nSpring(float weight); /*
+        ImGui::Spring(weight);
+    */
+
+    private static native void nSpring(float weight, float spacing); /*
+        ImGui::Spring(weight, spacing);
+    */
+
+    public static void suspendLayout() {
+        nSuspendLayout();
+    }
+
+    private static native void nSuspendLayout(); /*
+        ImGui::SuspendLayout();
+    */
+
+    public static void resumeLayout() {
+        nResumeLayout();
+    }
+
+    private static native void nResumeLayout(); /*
+        ImGui::ResumeLayout();
     */
 }

--- a/imgui-binding/src/generated/java/imgui/ImGuiIO.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiIO.java
@@ -1,6 +1,13 @@
 package imgui;
 
 import imgui.binding.ImGuiStruct;
+
+
+
+
+
+
+
 import imgui.callback.ImStrConsumer;
 import imgui.callback.ImStrSupplier;
 import imgui.internal.ImGuiContext;
@@ -9,6 +16,7 @@ import imgui.internal.ImGuiContext;
  * Communicate most settings and inputs/outputs to Dear ImGui using this structure.
  * Access via ImGui::GetIO(). Read 'Programmer guide' section in .cpp file for general usage.
  */
+
 public final class ImGuiIO extends ImGuiStruct {
     public ImGuiIO(final long ptr) {
         super(ptr);
@@ -23,7 +31,7 @@ public final class ImGuiIO extends ImGuiStruct {
     // Configuration (fill once)
     //------------------------------------------------------------------
 
-    /**
+     /**
      * See ImGuiConfigFlags enum. Set by user/application. Gamepad/keyboard navigation options, etc.
      */
     public int getConfigFlags() {
@@ -66,7 +74,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigFlags = value;
     */
 
-    /**
+     /**
      * See ImGuiBackendFlags enum. Set by backend to communicate features supported by the backend.
      */
     public int getBackendFlags() {
@@ -109,7 +117,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->BackendFlags = value;
     */
 
-    /**
+     /**
      * Main display size, in pixels (generally == {@code GetMainViewport()->Size}). May change every frame.
      */
     public ImVec2 getDisplaySize() {
@@ -170,7 +178,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->DisplaySize = value;
     */
 
-    /**
+     /**
      * Time elapsed since last frame, in seconds. May change every frame.
      */
     public float getDeltaTime() {
@@ -192,7 +200,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->DeltaTime = value;
     */
 
-    /**
+     /**
      * Minimum time between saving positions/sizes to .ini file, in seconds.
      */
     public float getIniSavingRate() {
@@ -214,7 +222,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->IniSavingRate = value;
     */
 
-    /**
+     /**
      * Path to .ini file. Set NULL to disable automatic .ini loading/saving, if e.g. you want to manually load/save from memory.
      */
     public String getIniFilename() {
@@ -238,7 +246,7 @@ public final class ImGuiIO extends ImGuiStruct {
         if (value != NULL) env->ReleaseStringUTFChars(obj_value, value);
     */
 
-    /**
+     /**
      * Path to .log file (default parameter to ImGui::LogToFile when no file is specified).
      */
     public String getLogFilename() {
@@ -262,7 +270,7 @@ public final class ImGuiIO extends ImGuiStruct {
         if (value != NULL) env->ReleaseStringUTFChars(obj_value, value);
     */
 
-    private static final ImFontAtlas _GETFONTS_1 = new ImFontAtlas(0);
+     private static final ImFontAtlas _GETFONTS_1 = new ImFontAtlas(0);
 
     /**
      * Font atlas: load, rasterize and pack one or more fonts into a single texture.
@@ -287,7 +295,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->Fonts = reinterpret_cast<ImFontAtlas*>(value);
     */
 
-    /**
+     /**
      * Global scale all fonts
      */
     public float getFontGlobalScale() {
@@ -309,7 +317,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->FontGlobalScale = value;
     */
 
-    /**
+     /**
      * Allow user scaling text of individual window with CTRL+Wheel.
      */
     public boolean getFontAllowUserScaling() {
@@ -331,7 +339,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->FontAllowUserScaling = value;
     */
 
-    /**
+     /**
      * Font to use on NewFrame(). Use NULL to uses Fonts{@code ->}Fonts[0].
      */
     public ImFont getFontDefault() {
@@ -353,7 +361,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->FontDefault = reinterpret_cast<ImFont*>(value);
     */
 
-    /**
+     /**
      * For retina display or other situations where window coordinates are different from framebuffer coordinates. This generally ends up in ImDrawData::FramebufferScale.
      */
     public ImVec2 getDisplayFramebufferScale() {
@@ -416,7 +424,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Docking options (when ImGuiConfigFlags_DockingEnable is set)
 
-    /**
+     /**
      * Simplified docking mode: disable window splitting, so docking is limited to merging multiple windows together into tab-bars.
      */
     public boolean getConfigDockingNoSplit() {
@@ -438,7 +446,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDockingNoSplit = value;
     */
 
-    /**
+     /**
      * Enable docking with holding Shift key (reduce visual noise, allows dropping in wider space)
      */
     public boolean getConfigDockingWithShift() {
@@ -476,7 +484,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDockingAlwaysTabBar = value;
     */
 
-    /**
+     /**
      * Make window or viewport transparent when docking and only display docking boxes on the target viewport. Useful if rendering of multiple viewport cannot be synced. Best used with ConfigViewportsNoAutoMerge.
      */
     public boolean getConfigDockingTransparentPayload() {
@@ -500,7 +508,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Viewport options (when ImGuiConfigFlags_ViewportsEnable is set)
 
-    /**
+     /**
      * Set to make all floating imgui windows always create their own viewport. Otherwise, they are merged into the main host viewports when overlapping it. May also set ImGuiViewportFlags_NoAutoMerge on individual viewport.
      */
     public boolean getConfigViewportsNoAutoMerge() {
@@ -522,7 +530,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigViewportsNoAutoMerge = value;
     */
 
-    /**
+     /**
      * Disable default OS task bar icon flag for secondary viewports. When a viewport doesn't want a task bar icon, ImGuiViewportFlags_NoTaskBarIcon will be set on it.
      */
     public boolean getConfigViewportsNoTaskBarIcon() {
@@ -544,7 +552,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigViewportsNoTaskBarIcon = value;
     */
 
-    /**
+     /**
      * Disable default OS window decoration flag for secondary viewports. When a viewport doesn't want window decorations, ImGuiViewportFlags_NoDecoration will be set on it. Enabling decoration can create subsequent issues at OS levels (e.g. minimum window size).
      */
     public boolean getConfigViewportsNoDecoration() {
@@ -566,7 +574,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigViewportsNoDecoration = value;
     */
 
-    /**
+     /**
      * Disable default OS parenting to main viewport for secondary viewports. By default, viewports are marked with ParentViewportId = {@code <main_viewport>}, expecting the platform backend to setup a parent/child relationship between the OS windows (some backend may ignore this). Set to true if you want the default to be 0, then all viewports will be top-level OS windows.
      */
     public boolean getConfigViewportsNoDefaultParent() {
@@ -590,7 +598,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Miscellaneous options
 
-    /**
+     /**
      * Request ImGui to draw a mouse cursor for you (if you are on a platform without a mouse cursor).
      * Cannot be easily renamed to 'io.ConfigXXX' because this is frequently used by backend implementations.
      */
@@ -614,7 +622,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDrawCursor = value;
     */
 
-    /**
+     /**
      * OS X style: Text editing cursor movement using Alt instead of Ctrl, Shortcuts using Cmd/Super instead of Ctrl,
      * Line/Text Start and End using Cmd+Arrows instead of Home/End, Double click selects by word instead of selecting whole text,
      * Multi-selection in lists uses Cmd/Super instead of Ctrl
@@ -640,7 +648,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigMacOSXBehaviors = value;
     */
 
-    /**
+     /**
      * Enable input queue trickling: some types of events submitted during the same frame (e.g. button down + up) will be spread over multiple frames, improving interactions with low framerates.
      */
     public boolean getConfigInputTrickleEventQueue() {
@@ -662,7 +670,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigInputTrickleEventQueue = value;
     */
 
-    /**
+     /**
      * Set to false to disable blinking cursor, for users who consider it distracting.
      */
     public boolean getConfigInputTextCursorBlink() {
@@ -684,7 +692,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigInputTextCursorBlink = value;
     */
 
-    /**
+     /**
      * [BETA] Pressing Enter will keep item active and select contents (single-line only).
      */
     public boolean getConfigInputTextEnterKeepActive() {
@@ -706,7 +714,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigInputTextEnterKeepActive = value;
     */
 
-    /**
+     /**
      * [BETA] Enable turning DragXXX widgets into text input with a simple mouse click-release (without moving). Not desirable on devices without a keyboard.
      */
     public boolean getConfigDragClickToInputText() {
@@ -728,7 +736,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDragClickToInputText = value;
     */
 
-    /**
+     /**
      * Enable resizing of windows from their edges and from the lower-left corner.
      * This requires (io.BackendFlags {@code &} ImGuiBackendFlags_HasMouseCursors) because it needs mouse cursor feedback.
      * (This used to be a per-window ImGuiWindowFlags_ResizeFromAnySide flag)
@@ -754,7 +762,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigWindowsResizeFromEdges = value;
     */
 
-    /**
+     /**
      * Enable allowing to move windows only when clicking on their title bar. Does not apply to windows without a title bar.
      */
     public boolean getConfigWindowsMoveFromTitleBarOnly() {
@@ -776,7 +784,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigWindowsMoveFromTitleBarOnly = value;
     */
 
-    /**
+     /**
      * [Timer (in seconds) to free transient windows/tables memory buffers when unused. Set to -1.0f to disable.
      */
     public boolean getConfigMemoryCompactTimer() {
@@ -802,7 +810,7 @@ public final class ImGuiIO extends ImGuiStruct {
     // (other variables, ones which are expected to be tweaked within UI code, are exposed in ImGuiStyle)
 
 
-    /**
+     /**
      * Time for a double-click, in seconds.
      */
     public float getMouseDoubleClickTime() {
@@ -824,7 +832,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDoubleClickTime = value;
     */
 
-    /**
+     /**
      * Distance threshold to stay in to validate a double-click, in pixels.
      */
     public float getMouseDoubleClickMaxDist() {
@@ -846,7 +854,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDoubleClickMaxDist = value;
     */
 
-    /**
+     /**
      * Distance threshold before considering we are dragging.
      */
     public float getMouseDragThreshold() {
@@ -868,7 +876,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDragThreshold = value;
     */
 
-    /**
+     /**
      * When holding a key/button, time before it starts repeating, in seconds (for buttons in Repeat mode, etc.).
      */
     public float getKeyRepeatDelay() {
@@ -890,7 +898,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyRepeatDelay = value;
     */
 
-    /**
+     /**
      * When holding a key/button, rate at which it repeats, in seconds.
      */
     public float getKeyRepeatRate() {
@@ -916,7 +924,7 @@ public final class ImGuiIO extends ImGuiStruct {
     // Debug options
     //------------------------------------------------------------------
 
-    /**
+     /**
      * Tools to test correct Begin/End and BeginChild/EndChild behaviors.
      * Presently Begin()/End() and BeginChild()/EndChild() needs to ALWAYS be called in tandem, regardless of return value of BeginXXX()
      * This is inconsistent with other BeginXXX functions and create confusion for many users.
@@ -946,7 +954,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDebugBeginReturnValueOnce = value;
     */
 
-    /**
+     /**
      * Some calls to Begin()/BeginChild() will return false. Will cycle through window depths then repeat.
      * Suggested use: add "io.ConfigDebugBeginReturnValue = io.KeyShift" in your main loop then occasionally press SHIFT.
      * Windows should be flickering while running.
@@ -972,7 +980,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDebugBeginReturnValueLoop = value;
     */
 
-    /**
+     /**
      * Option to deactivate io.AddFocusEvent(false) handling. May facilitate interactions with a debugger when focus loss leads to clearing inputs data.
      * Backends may have other side-effects on focus loss, so this will reduce side-effects but not necessary remove all of them.
      * Consider using e.g. Win32's IsDebuggerPresent() as an additional filter (or see ImOsIsDebuggerPresent() in imgui_test_engine/imgui_te_utils.cpp for a Unix compatible version).
@@ -1000,7 +1008,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->ConfigDebugIgnoreFocusLoss = value;
     */
 
-    /**
+     /**
      * Option to audit .ini data
      * Save .ini data with extra comments (particularly helpful for Docking, but makes saving slower)
      */
@@ -1028,7 +1036,7 @@ public final class ImGuiIO extends ImGuiStruct {
     // Platform Functions
     //------------------------------------------------------------------
 
-    /**
+     /**
      * Optional: Platform backend name (informational only! will be displayed in About Window) + User data for backend/wrappers to store their own stuff.
      */
     public String getBackendPlatformName() {
@@ -1104,7 +1112,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->GetClipboardTextFn = getClipboardTextStub;
     */
 
-    /**
+     /**
      * Optional: Platform locale
      * [Experimental] Configure decimal point e.g. '.' or ',' useful for some languages (e.g. German), generally pulled from {@code *localeconv()->decimal_point}
      */
@@ -1134,7 +1142,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Input Functions
 
-    /**
+     /**
      * Queue a new key down/up event. Key should be "translated" (as in, generally ImGuiKey_A matches the key end-user would use to emit an 'A' character)
      */
     public void addKeyEvent(final int key, final boolean down) {
@@ -1145,7 +1153,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddKeyEvent(static_cast<ImGuiKey>(key), down);
     */
 
-    /**
+     /**
      * Queue a new key down/up event for analog values (e.g. ImGuiKey_Gamepad_ values). Dead-zones should be handled by the backend.
      */
     public void addKeyAnalogEvent(final int key, final boolean down, final float v) {
@@ -1156,7 +1164,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddKeyAnalogEvent(static_cast<ImGuiKey>(key), down, v);
     */
 
-    /**
+     /**
      * Queue a mouse position update. Use -FLT_MAX,-FLT_MAX to signify no mouse (e.g. app not focused and not hovered)
      */
     public void addMousePosEvent(final float x, final float y) {
@@ -1167,7 +1175,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMousePosEvent(x, y);
     */
 
-    /**
+     /**
      * Queue a mouse button change
      */
     public void addMouseButtonEvent(final int button, final boolean down) {
@@ -1178,7 +1186,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMouseButtonEvent(button, down);
     */
 
-    /**
+     /**
      * Queue a mouse wheel update.
      */
     public void addMouseWheelEvent(final float whX, final float whY) {
@@ -1189,7 +1197,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMouseWheelEvent(whX, whY);
     */
 
-    /**
+     /**
      * Queue a mouse source change (Mouse/TouchScreen/Pen)
      */
     public void addMouseSourceEvent(final int source) {
@@ -1200,7 +1208,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMouseSourceEvent(static_cast<ImGuiMouseSource>(source));
     */
 
-    /**
+     /**
      * Queue a mouse hovered viewport. Requires backend to set ImGuiBackendFlags_HasMouseHoveredViewport to call this (for multi-viewport support).
      */
     public void addMouseViewportEvent(final int id) {
@@ -1211,7 +1219,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddMouseViewportEvent(static_cast<ImGuiID>(id));
     */
 
-    /**
+     /**
      * Queue a gain/loss of focus for the application (generally based on OS/platform focus of your window)
      */
     public void addFocusEvent(final boolean focused) {
@@ -1222,7 +1230,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddFocusEvent(focused);
     */
 
-    /**
+     /**
      * Queue new character input.
      */
     public void addInputCharacter(final int c) {
@@ -1233,7 +1241,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddInputCharacter((unsigned int)c);
     */
 
-    /**
+     /**
      * Queue new character input from a UTF-16 character, it can be a surrogate
      */
     public void addInputCharacterUTF16(final short c) {
@@ -1244,7 +1252,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->AddInputCharacterUTF16((ImWchar16)c);
     */
 
-    /**
+     /**
      * Queue new characters input from a UTF-8 string.
      */
     public void addInputCharactersUTF8(final String str) {
@@ -1257,7 +1265,7 @@ public final class ImGuiIO extends ImGuiStruct {
         if (str != NULL) env->ReleaseStringUTFChars(obj_str, str);
     */
 
-    /**
+     /**
      * [Optional] Specify index for legacy {@code <1.87} IsKeyXXX() functions with native indices + specify native keycode, scancode.
      */
     public void setKeyEventNativeData(final int key, final int nativeKeycode, final int nativeScancode) {
@@ -1279,7 +1287,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->SetKeyEventNativeData(static_cast<ImGuiKey>(key), nativeKeycode, nativeScancode, nativeLegacyIndex);
     */
 
-    /**
+     /**
      * Set master flag for accepting key/mouse/text events (default to true). Useful if you have native dialog boxes that are interrupting your application loop/refresh, and you want to disable events being queued while your app is frozen.
      */
     public void setAppAcceptingEvents(final boolean acceptingEvents) {
@@ -1290,7 +1298,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->SetAppAcceptingEvents(acceptingEvents);
     */
 
-    /**
+     /**
      * Clear all incoming events.
      */
     public void clearEventsQueue() {
@@ -1307,7 +1315,7 @@ public final class ImGuiIO extends ImGuiStruct {
     //  generally easier and more correct to use their state BEFORE calling NewFrame(). See FAQ for details!)
     //------------------------------------------------------------------
 
-    /**
+     /**
      * Set when Dear ImGui will use mouse inputs, in this case do not dispatch them to your main game/application
      * (either way, always pass on mouse inputs to imgui).
      * (e.g. unclicked mouse is hovering over an imgui window, widget is active, mouse was clicked over an imgui window, etc.).
@@ -1333,7 +1341,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantCaptureMouse = value;
     */
 
-    /**
+     /**
      * Set when Dear ImGui will use keyboard inputs, in this case do not dispatch them to your main game/application
      * (either way, always pass keyboard inputs to imgui). (e.g. InputText active, or an imgui window is focused and navigation is enabled, etc.).
      */
@@ -1357,7 +1365,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantCaptureKeyboard = value;
     */
 
-    /**
+     /**
      * Mobile/console: when set, you may display an on-screen keyboard.
      * This is set by Dear ImGui when it wants textual keyboard input to happen (e.g. when a InputText widget is active).
      */
@@ -1381,7 +1389,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantTextInput = value;
     */
 
-    /**
+     /**
      * MousePos has been altered, backend should reposition mouse on next frame. Rarely used! Set only when ImGuiConfigFlags_NavEnableSetMousePos flag is enabled.
      */
     public boolean getWantSetMousePos() {
@@ -1403,7 +1411,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantSetMousePos = value;
     */
 
-    /**
+     /**
      * When manual .ini load/save is active (io.IniFilename == NULL),
      * this will be set to notify your application that you can call SaveIniSettingsToMemory() and save yourself.
      * Important: clear io.WantSaveIniSettings yourself after saving!
@@ -1429,7 +1437,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantSaveIniSettings = value;
     */
 
-    /**
+     /**
      * Keyboard/Gamepad navigation is currently allowed (will handle ImGuiKey_NavXXX events) = a window is focused
      * and it doesn't use the ImGuiWindowFlags_NoNavInputs flag.
      */
@@ -1453,7 +1461,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->NavActive = value;
     */
 
-    /**
+     /**
      * Keyboard/Gamepad navigation is visible and allowed (will handle ImGuiKey_NavXXX events).
      */
     public boolean getNavVisible() {
@@ -1475,7 +1483,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->NavVisible = value;
     */
 
-    /**
+     /**
      * Estimate of application framerate (rolling average over 60 frames, based on io.DeltaTime), in frame per second.
      * Solely for convenience.
      * Slow applications may not want to use a moving average or may want to reset underlying buffers occasionally.
@@ -1501,7 +1509,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->Framerate = value;
     */
 
-    /**
+     /**
      * Vertices output during last call to Render()
      */
     public int getMetricsRenderVertices() {
@@ -1523,7 +1531,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsRenderVertices = value;
     */
 
-    /**
+     /**
      * Indices output during last call to Render() = number of triangles * 3
      */
     public int getMetricsRenderIndices() {
@@ -1545,7 +1553,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsRenderIndices = value;
     */
 
-    /**
+     /**
      * Number of visible windows
      */
     public int getMetricsRenderWindows() {
@@ -1567,7 +1575,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsRenderWindows = value;
     */
 
-    /**
+     /**
      * Number of active windows
      */
     public int getMetricsActiveWindows() {
@@ -1589,7 +1597,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsActiveWindows = value;
     */
 
-    /**
+     /**
      * Number of active allocations, updated by MemAlloc/MemFree based on current context. May be off if you have multiple imgui contexts.
      */
     public int getMetricsActiveAllocations() {
@@ -1611,7 +1619,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MetricsActiveAllocations = value;
     */
 
-    /**
+     /**
      * Mouse delta. Note that this is zero if either current or previous position are invalid (-FLT_MAX,-FLT_MAX), so a disappearing/reappearing mouse won't have a huge delta.
      */
     public ImVec2 getMouseDelta() {
@@ -1672,7 +1680,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDelta = value;
     */
 
-    /**
+     /**
      * Map of indices into the KeysDown[512] entries array which represent your "native" keyboard state.
      */
     @Deprecated
@@ -1730,7 +1738,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyMap[idx] = value;
     */
 
-    /**
+     /**
      * Keyboard keys that are pressed (ideally left in the "native" order your engine has access to keyboard keys, so you can use your own defines/enums for keys).
      * This used to be [512] sized. It is now ImGuiKey_COUNT to allow legacy io.KeysDown[GetKeyIndex(...)] to work without an overflow.
      */
@@ -1792,7 +1800,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeysDown[idx] = value;
     */
 
-    /**
+     /**
      * Gamepad inputs. Cleared back to zero by EndFrame(). Keyboard keys will be auto-mapped and be written here by NewFrame().
      */
     public float[] getNavInputs() {
@@ -1846,7 +1854,7 @@ public final class ImGuiIO extends ImGuiStruct {
     // [Internal] Dear ImGui will maintain those fields. Forward compatibility not guaranteed!
     //------------------------------------------------------------------
 
-    private static final ImGuiContext _GETCTX_1 = new ImGuiContext(0);
+     private static final ImGuiContext _GETCTX_1 = new ImGuiContext(0);
 
     /**
      * Parent UI context (needs to be set explicitly by parent).
@@ -1871,7 +1879,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->Ctx = reinterpret_cast<ImGuiContext*>(value);
     */
 
-    /**
+     /**
      * Mouse position, in pixels. Set to ImVec2(-FLT_MAX, -FLT_MAX) if mouse is unavailable (on another screen, etc.)
      */
     public ImVec2 getMousePos() {
@@ -1932,7 +1940,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MousePos = value;
     */
 
-    /**
+     /**
      * Mouse buttons: 0=left, 1=right, 2=middle + extras (ImGuiMouseButton_COUNT == 5). Dear ImGui mostly uses left and right buttons.
      * Others buttons allows us to track if the mouse is being used by your application + available to user as a convenience via IsMouse** API.
      */
@@ -1986,7 +1994,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDown[idx] = value;
     */
 
-    /**
+     /**
      * Mouse wheel Vertical: 1 unit scrolls about 5 lines text.
      */
     public float getMouseWheel() {
@@ -2008,7 +2016,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseWheel = value;
     */
 
-    /**
+     /**
      * Mouse wheel Horizontal. Most users don't have a mouse with an horizontal wheel, may not be filled by all backends.
      */
     public float getMouseWheelH() {
@@ -2030,7 +2038,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseWheelH = value;
     */
 
-    /**
+     /**
      * (Optional) When using multiple viewports: viewport the OS mouse cursor is hovering _IGNORING_ viewports with the ImGuiViewportFlags_NoInputs flag,
      * and _REGARDLESS_ of whether another viewport is focused. Set io.BackendFlags |= ImGuiBackendFlags_HasMouseHoveredViewport if you can provide this info.
      * If you don't imgui will infer the value using the rectangles and last focused time of the viewports it knows about (ignoring other OS windows).
@@ -2056,7 +2064,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseHoveredViewport = value;
     */
 
-    /**
+     /**
      * Keyboard modifier pressed: Control
      */
     public boolean getKeyCtrl() {
@@ -2078,7 +2086,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyCtrl = value;
     */
 
-    /**
+     /**
      * Keyboard modifier pressed: Shift
      */
     public boolean getKeyShift() {
@@ -2100,7 +2108,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyShift = value;
     */
 
-    /**
+     /**
      * Keyboard modifier pressed: Alt
      */
     public boolean getKeyAlt() {
@@ -2122,7 +2130,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyAlt = value;
     */
 
-    /**
+     /**
      * Keyboard modifier pressed: Cmd/Super/Windows
      */
     public boolean getKeySuper() {
@@ -2146,7 +2154,7 @@ public final class ImGuiIO extends ImGuiStruct {
 
     // Other state maintained from data above + IO function calls
 
-    /**
+     /**
      * Key mods flags (same as io.KeyCtrl/KeyShift/KeyAlt/KeySuper but merged into flags), updated by NewFrame()
      */
     public int getKeyMods() {
@@ -2168,7 +2176,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->KeyMods = value;
     */
 
-    /**
+     /**
      * Key state for all known keys. Use IsKeyXXX() functions to access this.
      */
     public ImGuiKeyData[] getKeysData() {
@@ -2190,7 +2198,7 @@ public final class ImGuiIO extends ImGuiStruct {
         Jni::ImGuiKeyDataArrayCpy(env, value, THIS->KeysData, ImGuiKey_KeysData_SIZE);
     */
 
-    /**
+     /**
      * Alternative to WantCaptureMouse: (WantCaptureMouse == true {@code &&} WantCaptureMouseUnlessPopupClose == false) when a click over void is expected to close a popup.
      */
     public boolean getWantCaptureMouseUnlessPopupClose() {
@@ -2212,7 +2220,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->WantCaptureMouseUnlessPopupClose = value;
     */
 
-    /**
+     /**
      * Previous mouse position (note that MouseDelta is not necessary == MousePos-MousePosPrev, in case either position is invalid)
      */
     public ImVec2 getMousePosPrev() {
@@ -2273,7 +2281,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MousePosPrev = value;
     */
 
-    /**
+     /**
      * Position at time of clicking.
      */
     public ImVec2[] getMouseClickedPos() {
@@ -2295,7 +2303,7 @@ public final class ImGuiIO extends ImGuiStruct {
         Jni::ImVec2ArrayCpy(env, value, THIS->MouseClickedPos, 5);
     */
 
-    /**
+     /**
      * Time of last click (used to figure out double-click)
      */
     public double[] getMouseClickedTime() {
@@ -2345,7 +2353,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseClickedTime[idx] = value;
     */
 
-    /**
+     /**
      * Mouse button went from !Down to Down (same as MouseClickedCount[x] != 0)
      */
     public boolean[] getMouseClicked() {
@@ -2395,7 +2403,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseClicked[idx] = value;
     */
 
-    /**
+     /**
      * Has mouse button been double-clicked? (same as MouseClickedCount[x] == 2)
      */
     public boolean[] getMouseDoubleClicked() {
@@ -2445,7 +2453,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDoubleClicked[idx] = value;
     */
 
-    /**
+     /**
      * == 0 (not clicked), == 1 (same as MouseClicked[]), == 2 (double-clicked), == 3 (triple-clicked) etc. when going from !Down to Down
      */
     public int[] getMouseClickedCount() {
@@ -2495,7 +2503,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseClickedCount[idx] = value;
     */
 
-    /**
+     /**
      * Count successive number of clicks. Stays valid after mouse release. Reset after another click is done.
      */
     public int[] getMouseClickedLastCount() {
@@ -2545,7 +2553,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseClickedLastCount[idx] = value;
     */
 
-    /**
+     /**
      * Mouse button went from Down to !Down
      */
     public boolean[] getMouseReleased() {
@@ -2595,7 +2603,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseReleased[idx] = value;
     */
 
-    /**
+     /**
      * Track if button was clicked inside a dear imgui window or over void blocked by a popup. We don't request mouse capture from the application if click started outside ImGui bounds.
      */
     public boolean[] getMouseDownOwned() {
@@ -2645,7 +2653,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDownOwned[idx] = value;
     */
 
-    /**
+     /**
      * Track if button was clicked inside a dear imgui window.
      */
     public boolean[] getMouseDownOwnedUnlessPopupClose() {
@@ -2695,7 +2703,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDownOwnedUnlessPopupClose[idx] = value;
     */
 
-    /**
+     /**
      * On a non-Mac system, holding SHIFT requests WheelY to perform the equivalent of a WheelX event.
      * On a Mac system this is already enforced by the system.
      */
@@ -2719,7 +2727,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseWheelRequestAxisSwap = value;
     */
 
-    /**
+     /**
      * Duration the mouse button has been down (0.0f == just clicked)
      */
     public float[] getMouseDownDuration() {
@@ -2769,7 +2777,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDownDuration[idx] = value;
     */
 
-    /**
+     /**
      * Previous time the mouse button has been down
      */
     public float[] getMouseDownDurationPrev() {
@@ -2819,7 +2827,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDownDurationPrev[idx] = value;
     */
 
-    /**
+     /**
      * Maximum distance, absolute, on each axis, of how much mouse has traveled from the clicking point
      */
     public ImVec2[] getMouseDragMaxDistanceAbs() {
@@ -2841,7 +2849,7 @@ public final class ImGuiIO extends ImGuiStruct {
         Jni::ImVec2ArrayCpy(env, value, THIS->MouseDragMaxDistanceAbs, 5);
     */
 
-    /**
+     /**
      * Squared maximum distance of how much mouse has traveled from the clicking point
      */
     public float[] getMouseDragMaxDistanceSqr() {
@@ -2891,7 +2899,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->MouseDragMaxDistanceSqr[idx] = value;
     */
 
-    /**
+     /**
      * Touch/Pen pressure (0.0f to 1.0f, should be {@code >}0.0f only when MouseDown[0] == true). Helper storage currently unused by Dear ImGui.
      */
     public float getPenPressure() {
@@ -2913,7 +2921,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->PenPressure = value;
     */
 
-    /**
+     /**
      * Only modify via AddFocusEvent().
      */
     public boolean getAppFocusLost() {
@@ -2924,7 +2932,7 @@ public final class ImGuiIO extends ImGuiStruct {
         return THIS->AppFocusLost;
     */
 
-    /**
+     /**
      * Only modify via SetAppAcceptingEvents().
      */
     public boolean getAppAcceptingEvents() {
@@ -2935,7 +2943,7 @@ public final class ImGuiIO extends ImGuiStruct {
         return THIS->AppAcceptingEvents;
     */
 
-    /**
+     /**
      * -1: unknown, 0: using AddKeyEvent(), 1: using legacy io.KeysDown[]
      */
     public short getBackendUsingLegacyKeyArrays() {
@@ -2957,7 +2965,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->BackendUsingLegacyKeyArrays = value;
     */
 
-    /**
+     /**
      * 0: using AddKeyAnalogEvent(), 1: writing to legacy io.NavInputs[] directly
      */
     public boolean getBackendUsingLegacyNavInputArray() {
@@ -2979,7 +2987,7 @@ public final class ImGuiIO extends ImGuiStruct {
         THIS->BackendUsingLegacyNavInputArray = value;
     */
 
-    /**
+     /**
      * For AddInputCharacterUTF16
      */
     public short getInputQueueSurrogate() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiInputTextCallbackData.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiInputTextCallbackData.java
@@ -1,6 +1,10 @@
 package imgui;
 
 import imgui.binding.ImGuiStruct;
+
+
+
+
 import imgui.internal.ImGuiContext;
 
 /**
@@ -14,6 +18,7 @@ import imgui.internal.ImGuiContext;
  * - ImGuiInputTextFlags_CallbackCharFilter:  Callback on character inputs to replace or discard them. Modify 'EventChar' to replace or discard, or return 1 in callback to discard.<p>
  * - ImGuiInputTextFlags_CallbackResize:      Callback on buffer capacity changes request (beyond 'buf_size' parameter value), allowing the string to grow.<p>
  */
+
 public class ImGuiInputTextCallbackData extends ImGuiStruct {
     public ImGuiInputTextCallbackData(final long ptr) {
         super(ptr);
@@ -24,7 +29,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         #define THIS ((ImGuiInputTextCallbackData*)STRUCT_PTR)
      */
 
-    private static final ImGuiContext _GETCTX_1 = new ImGuiContext(0);
+     private static final ImGuiContext _GETCTX_1 = new ImGuiContext(0);
 
     /**
      * Parent UI context
@@ -49,7 +54,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->Ctx = reinterpret_cast<ImGuiContext*>(value);
     */
 
-    /**
+     /**
      * One ImGuiInputTextFlags_Callback*
      */
     public int getEventFlag() {
@@ -67,7 +72,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         return THIS->EventFlag;
     */
 
-    /**
+     /**
      * What user passed to InputText()
      */
     public int getFlags() {
@@ -87,7 +92,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
 
     // TODO: UserData
 
-    /**
+     /**
      * [CharFilter] Replace character with another one, or set to zero to drop. return 1 is equivalent to setting EventChar=0;
      */
     public int getEventChar() {
@@ -109,7 +114,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->EventChar = value;
     */
 
-    /**
+     /**
      * [Completion,History]
      */
     public int getEventKey() {
@@ -120,7 +125,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         return THIS->EventKey;
     */
 
-    /**
+     /**
      * [Resize] Can replace pointer <p>
      * [Completion,History,Always] Only write to pointed data, don't replace the actual pointer!
      */
@@ -146,7 +151,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         if (value != NULL) env->ReleaseStringUTFChars(obj_value, value);
     */
 
-    /**
+     /**
      * [Resize,Completion,History,Always] Exclude zero-terminator storage. In C land: == strlen(some_text), in C++ land: string.length()
      */
     public int getBufTextLen() {
@@ -168,7 +173,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->BufTextLen = value;
     */
 
-    /**
+     /**
      * Set if you modify Buf/BufTextLen!
      */
     public boolean getBufDirty() {
@@ -190,7 +195,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->BufDirty = value;
     */
 
-    /**
+     /**
      * Current cursor position
      */
     public int getCursorPos() {
@@ -212,7 +217,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->CursorPos = value;
     */
 
-    /**
+     /**
      * Selection Start
      */
     public int getSelectionStart() {
@@ -234,7 +239,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->SelectionStart = value;
     */
 
-    /**
+     /**
      * Selection End
      */
     public int getSelectionEnd() {
@@ -256,7 +261,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->SelectionEnd = value;
     */
 
-    /**
+     /**
      * Delete Chars
      *
      * @param pos
@@ -272,7 +277,7 @@ public class ImGuiInputTextCallbackData extends ImGuiStruct {
         THIS->DeleteChars(pos, bytesCount);
     */
 
-    /**
+     /**
      * Insert Chars
      *
      * @param pos

--- a/imgui-binding/src/generated/java/imgui/ImGuiKeyData.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiKeyData.java
@@ -2,10 +2,13 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
 /**
  * [Internal] Storage used by IsKeyDown(), IsKeyPressed() etc functions.
  * If prior to 1.87 you used io.KeysDownDuration[] (which was marked as internal), you should use GetKeyData(key).DownDuration and not io.KeysData[key].DownDuration.
  */
+
 public final class ImGuiKeyData extends ImGuiStructDestroyable {
     public ImGuiKeyData() {
         super();
@@ -29,7 +32,7 @@ public final class ImGuiKeyData extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImGuiKeyData());
     */
 
-    /**
+     /**
      * True for if key is down
      */
     public boolean getDown() {
@@ -51,7 +54,7 @@ public final class ImGuiKeyData extends ImGuiStructDestroyable {
         THIS->Down = value;
     */
 
-    /**
+     /**
      * Duration the key has been down ({@code <}0.0f: not pressed, 0.0f: just pressed, {@code >}0.0f: time held)
      */
     public float getDownDuration() {
@@ -73,7 +76,7 @@ public final class ImGuiKeyData extends ImGuiStructDestroyable {
         THIS->DownDuration = value;
     */
 
-    /**
+     /**
      * Last frame duration the key has been down
      */
     public float getDownDurationPrev() {
@@ -95,7 +98,7 @@ public final class ImGuiKeyData extends ImGuiStructDestroyable {
         THIS->DownDurationPrev = value;
     */
 
-    /**
+     /**
      * 0.0f..1.0f for gamepad values
      */
     public float getAnalogValue() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiListClipper.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiListClipper.java
@@ -1,6 +1,11 @@
 package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
+
+
+
+
+
 import imgui.callback.ImListClipperCallback;
 import imgui.internal.ImGuiContext;
 
@@ -30,6 +35,7 @@ import java.util.function.Consumer;
  * - User code submit visible elements.
  * - The clipper also handles various subtleties related to keyboard/gamepad navigation, wrapping etc.
  */
+
 public final class ImGuiListClipper extends ImGuiStructDestroyable {
     public ImGuiListClipper() {
         super();
@@ -53,7 +59,7 @@ public final class ImGuiListClipper extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImGuiListClipper());
     */
 
-    private static final ImGuiContext _GETCTX_1 = new ImGuiContext(0);
+     private static final ImGuiContext _GETCTX_1 = new ImGuiContext(0);
 
     /**
      * Parent UI context
@@ -150,7 +156,7 @@ public final class ImGuiListClipper extends ImGuiStructDestroyable {
         THIS->Begin(itemsCount, itemsHeight);
     */
 
-    /**
+     /**
      * Automatically called on the last call of Step() that returns false.
      */
     public void end() {
@@ -161,7 +167,7 @@ public final class ImGuiListClipper extends ImGuiStructDestroyable {
         THIS->End();
     */
 
-    /**
+     /**
      * Call until it returns false. The DisplayStart/DisplayEnd fields will be set and you can process/draw those items.
      */
     public boolean step() {
@@ -172,7 +178,7 @@ public final class ImGuiListClipper extends ImGuiStructDestroyable {
         return THIS->Step();
     */
 
-    /**
+     /**
      * Call IncludeItemByIndex() or IncludeItemsByIndex() *BEFORE* first call to Step() if you need a range of items to not be clipped, regardless of their visibility.
      * (Due to alignment / padding of certain items it is possible that an extra item may be included on either end of the display range).
      */
@@ -184,7 +190,7 @@ public final class ImGuiListClipper extends ImGuiStructDestroyable {
         THIS->IncludeItemByIndex(itemIndex);
     */
 
-    /**
+     /**
      * Call IncludeItemByIndex() or IncludeItemsByIndex() *BEFORE* first call to Step() if you need a range of items to not be clipped, regardless of their visibility.
      * (Due to alignment / padding of certain items it is possible that an extra item may be included on either end of the display range).
      *

--- a/imgui-binding/src/generated/java/imgui/ImGuiPlatformMonitor.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiPlatformMonitor.java
@@ -2,10 +2,13 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
 /**
  * (Optional) This is required when enabling multi-viewport. Represent the bounds of each connected monitor/display and their DPI.
  * We use this information for multiple DPI support + clamping the position of popups and tooltips so they don't straddle multiple monitors.
  */
+
 public final class ImGuiPlatformMonitor extends ImGuiStruct {
     public ImGuiPlatformMonitor(final long ptr) {
         super(ptr);
@@ -16,7 +19,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         #define THIS ((ImGuiPlatformMonitor*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Coordinates of the area displayed on this monitor (Min = upper left, Max = bottom right)
      */
     public ImVec2 getMainPos() {
@@ -77,7 +80,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         THIS->MainPos = value;
     */
 
-    /**
+     /**
      * Coordinates of the area displayed on this monitor (Min = upper left, Max = bottom right)
      */
     public ImVec2 getMainSize() {
@@ -138,7 +141,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         THIS->MainSize = value;
     */
 
-    /**
+     /**
      * Coordinates without task bars / side bars / menu bars.
      * Used to avoid positioning popups/tooltips inside this region. If you don't have this info, please copy the value for MainPos/MainSize.
      */
@@ -205,7 +208,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         THIS->WorkPos = value;
     */
 
-    /**
+     /**
      * Coordinates without task bars / side bars / menu bars.
      * Used to avoid positioning popups/tooltips inside this region. If you don't have this info, please copy the value for MainPos/MainSize.
      */
@@ -272,7 +275,7 @@ public final class ImGuiPlatformMonitor extends ImGuiStruct {
         THIS->WorkSize = value;
     */
 
-    /**
+     /**
      * 1.0f = 96 DPI
      */
     public float getDpiScale() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiStorage.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiStorage.java
@@ -2,6 +2,9 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 /**
  * Helper: Key-Value storage
  * Typically you don't have to worry about this since a storage is held within each Window.
@@ -12,6 +15,7 @@ import imgui.binding.ImGuiStructDestroyable;
  * - You want to store custom debug data easily without adding or editing structures in your code (probably not efficient, but convenient)
  * Types are NOT stored, so it is up to you to make sure your Key don't collide with different types.
  */
+
 public final class ImGuiStorage extends ImGuiStructDestroyable {
     public ImGuiStorage() {
         super();
@@ -119,7 +123,7 @@ public final class ImGuiStorage extends ImGuiStructDestroyable {
         THIS->SetFloat(key, val);
     */
 
-    /**
+     /**
      * Use on your own storage if you know only integer are being stored (open/close all tree nodes)
      */
     public void setAllInt(final int val) {
@@ -130,7 +134,7 @@ public final class ImGuiStorage extends ImGuiStructDestroyable {
         THIS->SetAllInt(val);
     */
 
-    /**
+     /**
      * For quicker full rebuild of a storage (instead of an incremental one), you may add all your contents and then sort once.
      */
     public void buildSortByKey() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiStyle.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiStyle.java
@@ -2,11 +2,16 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
 /**
  * You may modify the ImGui::GetStyle() main instance during initialization and before NewFrame().
  * During the frame, use ImGui::PushStyleVar(ImGuiStyleVar_XXXX)/PopStyleVar() to alter the main style values,
  * and ImGui::PushStyleColor(ImGuiCol_XXX)/PopStyleColor() for colors.
  */
+
 public final class ImGuiStyle extends ImGuiStructDestroyable {
     public ImGuiStyle() {
         super();
@@ -30,7 +35,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImGuiStyle());
     */
 
-    /**
+     /**
      * Global alpha applies to everything in Dear ImGui.
      */
     public float getAlpha() {
@@ -52,7 +57,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->Alpha = value;
     */
 
-    /**
+     /**
      * Additional alpha multiplier applied by BeginDisabled(). Multiply over current value of Alpha.
      */
     public float getDisabledAlpha() {
@@ -74,7 +79,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->DisabledAlpha = value;
     */
 
-    /**
+     /**
      * Padding within a window.
      */
     public ImVec2 getWindowPadding() {
@@ -135,7 +140,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowPadding = value;
     */
 
-    /**
+     /**
      * Radius of window corners rounding. Set to 0.0f to have rectangular windows.
      * Large values tend to lead to variety of artifacts and are not recommended.
      */
@@ -159,7 +164,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
      */
     public float getWindowBorderSize() {
@@ -181,7 +186,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowBorderSize = value;
     */
 
-    /**
+     /**
      * Minimum window size. This is a global setting. If you want to constrain individual windows, use SetNextWindowSizeConstraints().
      */
     public ImVec2 getWindowMinSize() {
@@ -242,7 +247,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowMinSize = value;
     */
 
-    /**
+     /**
      * Alignment for title bar text. Defaults to (0.0f,0.5f) for left-aligned,vertically centered.
      */
     public ImVec2 getWindowTitleAlign() {
@@ -303,7 +308,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowTitleAlign = value;
     */
 
-    /**
+     /**
      * Side of the collapsing/docking button in the title bar (None/Left/Right). Defaults to ImGuiDir_Left.
      */
     public int getWindowMenuButtonPosition() {
@@ -325,7 +330,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->WindowMenuButtonPosition = value;
     */
 
-    /**
+     /**
      * Radius of child window corners rounding. Set to 0.0f to have rectangular windows.
      */
     public float getChildRounding() {
@@ -347,7 +352,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ChildRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around child windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
      */
     public float getChildBorderSize() {
@@ -369,7 +374,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ChildBorderSize = value;
     */
 
-    /**
+     /**
      * Radius of popup window corners rounding. (Note that tooltip windows use WindowRounding)
      */
     public float getPopupRounding() {
@@ -391,7 +396,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->PopupRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around popup/tooltip windows. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
      */
     public float getPopupBorderSize() {
@@ -413,7 +418,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->PopupBorderSize = value;
     */
 
-    /**
+     /**
      * Padding within a framed rectangle (used by most widgets).
      */
     public ImVec2 getFramePadding() {
@@ -474,7 +479,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->FramePadding = value;
     */
 
-    /**
+     /**
      * Radius of frame corners rounding. Set to 0.0f to have rectangular frame (used by most widgets).
      */
     public float getFrameRounding() {
@@ -496,7 +501,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->FrameRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around frames. Generally set to 0.0f or 1.0f. (Other values are not well tested and more CPU/GPU costly).
      */
     public float getFrameBorderSize() {
@@ -518,7 +523,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->FrameBorderSize = value;
     */
 
-    /**
+     /**
      * Horizontal and vertical spacing between widgets/lines.
      */
     public ImVec2 getItemSpacing() {
@@ -579,7 +584,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ItemSpacing = value;
     */
 
-    /**
+     /**
      * Horizontal and vertical spacing between within elements of a composed widget (e.g. a slider and its label).
      */
     public ImVec2 getItemInnerSpacing() {
@@ -640,7 +645,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ItemInnerSpacing = value;
     */
 
-    /**
+     /**
      * Padding within a table cell. CellPadding.y may be altered between different rows.
      */
     public ImVec2 getCellPadding() {
@@ -701,7 +706,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->CellPadding = value;
     */
 
-    /**
+     /**
      * Expand reactive bounding box for touch-based system where touch position is not accurate enough.
      * Unfortunately we don't sort widgets so priority on overlap will always be given to the first widget. So don't grow this too much!
      */
@@ -768,7 +773,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->TouchExtraPadding = value;
     */
 
-    /**
+     /**
      * Horizontal indentation when e.g. entering a tree node. Generally == (FontSize + FramePadding.x*2).
      */
     public float getIndentSpacing() {
@@ -790,7 +795,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->IndentSpacing = value;
     */
 
-    /**
+     /**
      * Minimum horizontal spacing between two columns. Preferably {@code >} (FramePadding.x + 1).
      */
     public float getColumnsMinSpacing() {
@@ -812,7 +817,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ColumnsMinSpacing = value;
     */
 
-    /**
+     /**
      * Width of the vertical scrollbar, Height of the horizontal scrollbar.
      */
     public float getScrollbarSize() {
@@ -834,7 +839,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ScrollbarSize = value;
     */
 
-    /**
+     /**
      * Radius of grab corners for scrollbar.
      */
     public float getScrollbarRounding() {
@@ -856,7 +861,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ScrollbarRounding = value;
     */
 
-    /**
+     /**
      * Minimum width/height of a grab box for slider/scrollbar.
      */
     public float getGrabMinSize() {
@@ -878,7 +883,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->GrabMinSize = value;
     */
 
-    /**
+     /**
      * Radius of grabs corners rounding. Set to 0.0f to have rectangular slider grabs.
      */
     public float getGrabRounding() {
@@ -900,7 +905,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->GrabRounding = value;
     */
 
-    /**
+     /**
      * The size in pixels of the dead-zone around zero on logarithmic sliders that cross zero.
      */
     public float getLogSliderDeadzone() {
@@ -922,7 +927,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->LogSliderDeadzone = value;
     */
 
-    /**
+     /**
      * Radius of upper corners of a tab. Set to 0.0f to have rectangular tabs.
      */
     public float getTabRounding() {
@@ -944,7 +949,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->TabRounding = value;
     */
 
-    /**
+     /**
      * Thickness of border around tabs.
      */
     public float getTabBorderSize() {
@@ -966,7 +971,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->TabBorderSize = value;
     */
 
-    /**
+     /**
      * Minimum width for close button to appear on an unselected tab when hovered.
      * Set to 0.0f to always show when hovering, set to FLT_MAX to never show close button unless selected.
      */
@@ -990,7 +995,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->TabMinWidthForCloseButton = value;
     */
 
-    /**
+     /**
      * Side of the color button in the ColorEdit4 widget (left/right). Defaults to ImGuiDir_Right.
      */
     public int getColorButtonPosition() {
@@ -1012,7 +1017,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ColorButtonPosition = value;
     */
 
-    /**
+     /**
      * Alignment of button text when button is larger than text. Defaults to (0.5f, 0.5f) (centered).
      */
     public ImVec2 getButtonTextAlign() {
@@ -1073,7 +1078,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->ButtonTextAlign = value;
     */
 
-    /**
+     /**
      * Alignment of selectable text. Defaults to (0.0f, 0.0f) (top-left aligned).
      * It's generally important to keep this left-aligned if you want to lay multiple items on a same line.
      */
@@ -1140,7 +1145,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->SelectableTextAlign = value;
     */
 
-    /**
+     /**
      * Thickkness of border in SeparatorText()
      */
     public float getSeparatorTextBorderSize() {
@@ -1162,7 +1167,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->SeparatorTextBorderSize = value;
     */
 
-    /**
+     /**
      * Alignment of text within the separator. Defaults to (0.0f, 0.5f) (left aligned, center).
      */
     public ImVec2 getSeparatorTextAlign() {
@@ -1223,7 +1228,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->SeparatorTextAlign = value;
     */
 
-    /**
+     /**
      * Horizontal offset of text from each edge of the separator + spacing on other axis. Generally small values. .y is recommended to be == FramePadding.y.
      */
     public ImVec2 getSeparatorTextPadding() {
@@ -1284,7 +1289,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->SeparatorTextPadding = value;
     */
 
-    /**
+     /**
      * Window position are clamped to be visible within the display area by at least this amount. Only applies to regular windows.
      */
     public ImVec2 getDisplayWindowPadding() {
@@ -1345,7 +1350,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->DisplayWindowPadding = value;
     */
 
-    /**
+     /**
      * If you cannot see the edges of your screen (e.g. on a TV) increase the safe area padding.
      * Apply to popups/tooltips as well regular windows. NB: Prefer configuring your TV sets correctly!
      */
@@ -1412,7 +1417,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->DisplaySafeAreaPadding = value;
     */
 
-    /**
+     /**
      * Thickness of resizing border between docked windows
      */
     public float getDockingSeparatorSize() {
@@ -1434,7 +1439,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->DockingSeparatorSize = value;
     */
 
-    /**
+     /**
      * Scale software rendered mouse cursor (when io.MouseDrawCursor is enabled). May be removed later.
      */
     public float getMouseCursorScale() {
@@ -1456,7 +1461,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->MouseCursorScale = value;
     */
 
-    /**
+     /**
      * Enable anti-aliased lines/borders. Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame (copied to ImDrawList).
      */
     public boolean getAntiAliasedLines() {
@@ -1478,7 +1483,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->AntiAliasedLines = value;
     */
 
-    /**
+     /**
      * Enable anti-aliased lines/borders using textures where possible.
      * Require backend to render with bilinear filtering (NOT point/nearest filtering).
      * Latched at the beginning of the frame (copied to ImDrawList).
@@ -1504,7 +1509,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->AntiAliasedLinesUseTex = value;
     */
 
-    /**
+     /**
      * Enable anti-aliased edges around filled shapes (rounded rectangles, circles, etc.).
      * Disable if you are really tight on CPU/GPU. Latched at the beginning of the frame (copied to ImDrawList).
      */
@@ -1528,7 +1533,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->AntiAliasedFill = value;
     */
 
-    /**
+     /**
      * Tessellation tolerance when using PathBezierCurveTo() without a specific number of segments.
      * Decrease for highly tessellated curves (higher quality, more polygons), increase to reduce quality.
      */
@@ -1552,7 +1557,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->CurveTessellationTol = value;
     */
 
-    /**
+     /**
      * Maximum error (in pixels) allowed when using AddCircle()/AddCircleFilled() or drawing rounded corner rectangles with no explicit segment count specified.
      * Decrease for higher quality but more geometry.
      */
@@ -1617,7 +1622,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
     // Behaviors
     // (It is possible to modify those fields mid-frame if specific behavior need it, unlike e.g. configuration fields in ImGuiIO)
 
-    /**
+     /**
      * Delay for IsItemHovered(ImGuiHoveredFlags_Stationary). Time required to consider mouse stationary.
      */
     public float getHoverStationaryDelay() {
@@ -1639,7 +1644,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->HoverStationaryDelay = value;
     */
 
-    /**
+     /**
      * Delay for IsItemHovered(ImGuiHoveredFlags_DelayShort). Usually used along with HoverStationaryDelay.
      */
     public float getHoverDelayShort() {
@@ -1661,7 +1666,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->HoverDelayShort = value;
     */
 
-    /**
+     /**
      * Delay for IsItemHovered(ImGuiHoveredFlags_DelayNormal). "
      */
     public float getHoverDelayNormal() {
@@ -1683,7 +1688,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->HoverDelayNormal = value;
     */
 
-    /**
+     /**
      * Default flags when using IsItemHovered(ImGuiHoveredFlags_ForTooltip) or BeginItemTooltip()/SetItemTooltip() while using mouse.
      */
     public int getHoverFlagsForTooltipMouse() {
@@ -1705,7 +1710,7 @@ public final class ImGuiStyle extends ImGuiStructDestroyable {
         THIS->HoverFlagsForTooltipMouse = value;
     */
 
-    /**
+     /**
      * Default flags when using IsItemHovered(ImGuiHoveredFlags_ForTooltip) or BeginItemTooltip()/SetItemTooltip() while using keyboard/gamepad.
      */
     public int getHoverFlagsForTooltipNav() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiTableColumnSortSpecs.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTableColumnSortSpecs.java
@@ -2,9 +2,13 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 /**
  * Sorting specification for one column of a table.
  */
+
 public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
 
     public ImGuiTableColumnSortSpecs(final long ptr) {
@@ -16,7 +20,7 @@ public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
         #define THIS ((ImGuiTableColumnSortSpecs*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * User id of the column (if specified by a TableSetupColumn() call)
      */
     public int getColumnUserID() {
@@ -27,7 +31,7 @@ public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
         return THIS->ColumnUserID;
     */
 
-    /**
+     /**
      * Index of the column
      */
     public int getColumnIndex() {
@@ -38,7 +42,7 @@ public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
         return THIS->ColumnIndex;
     */
 
-    /**
+     /**
      * Index within parent ImGuiTableSortSpecs (always stored in order starting from 0, tables sorted on a single criteria will always have a 0 here)
      */
     public int getSortOrder() {
@@ -49,7 +53,7 @@ public final class ImGuiTableColumnSortSpecs extends ImGuiStruct {
         return THIS->SortOrder;
     */
 
-    /**
+     /**
      * ImGuiSortDirection_Ascending or ImGuiSortDirection_Descending (you can use this or SortSign, whichever is more convenient for your sort function)
      */
     public int getSortDirection() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiTableSortSpecs.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTableSortSpecs.java
@@ -2,12 +2,16 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 /**
  * Sorting specifications for a table (often handling sort specs for a single column, occasionally more)
  * Obtained by calling TableGetSortSpecs().
  * When 'SpecsDirty == true' you can sort your data. It will be true with sorting specs have changed since last call, or the first time.
  * Make sure to set 'SpecsDirty = false' after sorting, else you may wastefully sort your data every frame!
  */
+
 public final class ImGuiTableSortSpecs extends ImGuiStruct {
     public ImGuiTableSortSpecs(final long ptr) {
         super(ptr);
@@ -43,7 +47,7 @@ public final class ImGuiTableSortSpecs extends ImGuiStruct {
         return result;
     */
 
-    /**
+     /**
      * Sort spec count. Most often 1. May be {@code >} 1 when ImGuiTableFlags_SortMulti is enabled. May be == 0 when ImGuiTableFlags_SortTristate is enabled.
      */
     public int getSpecsCount() {
@@ -54,7 +58,7 @@ public final class ImGuiTableSortSpecs extends ImGuiStruct {
         return THIS->SpecsCount;
     */
 
-    /**
+     /**
      * Set to true when specs have changed since last time! Use this to sort again, then clear the flag.
      */
     public boolean getSpecsDirty() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiTextFilter.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiTextFilter.java
@@ -2,9 +2,14 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
 /**
  * Helper: Parse and apply text filters. In format "aaaaa[,bbbb][,ccccc]"
  */
+
 public final class ImGuiTextFilter extends ImGuiStructDestroyable {
     public ImGuiTextFilter() {
         this("");

--- a/imgui-binding/src/generated/java/imgui/ImGuiViewport.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiViewport.java
@@ -2,11 +2,16 @@ package imgui;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
 /**
  * The viewports created and managed by Dear ImGui. The role of the platform backend is to create the platform/OS windows corresponding to each viewport.
  * - Main Area = entire viewport.
  * - Work Area = entire viewport minus sections optionally used by menu bars, status bars. Some positioning code will prefer to use this. Window are also trying to stay within this area.
  */
+
 public final class ImGuiViewport extends ImGuiStruct {
     public ImGuiViewport(final long ptr) {
         super(ptr);
@@ -17,7 +22,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         #define THIS ((ImGuiViewport*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Unique identifier for the viewport.
      */
     public int getID() {
@@ -39,7 +44,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->ID = value;
     */
 
-    /**
+     /**
      * See {@link imgui.flag.ImGuiViewportFlags}.
      */
     public int getFlags() {
@@ -82,7 +87,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->Flags = value;
     */
 
-    /**
+     /**
      * Main Area: Position of the viewport (the imgui coordinates are the same as OS desktop/native coordinates).
      */
     public ImVec2 getPos() {
@@ -143,7 +148,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->Pos = value;
     */
 
-    /**
+     /**
      * Main Area: Size of the viewport.
      */
     public ImVec2 getSize() {
@@ -204,7 +209,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->Size = value;
     */
 
-    /**
+     /**
      * Work Area: Position of the viewport minus task bars, menus bars, status bars.
      */
     public ImVec2 getWorkPos() {
@@ -265,7 +270,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->WorkPos = value;
     */
 
-    /**
+     /**
      * Work Area: Size of the viewport minus task bars, menu bars, status bars.
      */
     public ImVec2 getWorkSize() {
@@ -326,7 +331,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->WorkSize = value;
     */
 
-    /**
+     /**
      * 1.0f = 96 DPI = No extra scale.
      */
     public float getDpiScale() {
@@ -348,7 +353,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->DpiScale = value;
     */
 
-    /**
+     /**
      * (Advanced) 0: no parent. Instruct the platform backend to setup a parent/child relationship between platform windows.
      */
     public int getParentViewportId() {
@@ -370,7 +375,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->ParentViewportId = value;
     */
 
-    /**
+     /**
      * The ImDrawData corresponding to this viewport. Valid after Render() and until the next call to NewFrame().
      */
     public ImDrawData getDrawData() {
@@ -459,7 +464,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         return (uintptr_t)THIS->PlatformHandleRaw;
     */
 
-    /**
+     /**
      * Platform window has been created (Platform_CreateWindow() has been called). This is false during the first frame where a viewport is being created.
      */
     public boolean getPlatformWindowCreated() {
@@ -481,7 +486,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->PlatformWindowCreated = value;
     */
 
-    /**
+     /**
      * Platform window requested move (e.g. window was moved by the OS / host window manager, authoritative position will be OS window position).
      */
     public boolean getPlatformRequestMove() {
@@ -503,7 +508,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->PlatformRequestMove = value;
     */
 
-    /**
+     /**
      * Platform window requested resize (e.g. window was resized by the OS / host window manager, authoritative size will be OS window size).
      */
     public boolean getPlatformRequestResize() {
@@ -525,7 +530,7 @@ public final class ImGuiViewport extends ImGuiStruct {
         THIS->PlatformRequestResize = value;
     */
 
-    /**
+     /**
      * Platform window requested closure (e.g. window was moved by the OS / host window manager, e.g. pressing ALT-F4).
      */
     public boolean getPlatformRequestClose() {

--- a/imgui-binding/src/generated/java/imgui/ImGuiWindowClass.java
+++ b/imgui-binding/src/generated/java/imgui/ImGuiWindowClass.java
@@ -2,6 +2,8 @@ package imgui;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
 /**
  * [ALPHA] Rarely used / very advanced uses only. Use with SetNextWindowClass() and DockSpace() functions.
  * Important: the content of this class is still highly WIP and likely to change and be refactored
@@ -11,6 +13,7 @@ import imgui.binding.ImGuiStructDestroyable;
  * - To the platform backend for OS level parent/child relationships of viewport.
  * - To the docking system for various options and filtering.
  */
+
 public final class ImGuiWindowClass extends ImGuiStructDestroyable {
     public ImGuiWindowClass() {
         super();
@@ -34,7 +37,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImGuiWindowClass());
     */
 
-    /**
+     /**
      * User data. 0 = Default class (unclassed). Windows of different classes cannot be docked with each others.
      */
     public int getClassId() {
@@ -56,7 +59,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->ClassId = value;
     */
 
-    /**
+     /**
      * Hint for the platform backend. If non-zero, the platform backend can create a parent{@code <>}child relationship between the platform windows.
      * Not conforming backends are free to e.g. parent every viewport to the main viewport or not.
      */
@@ -80,7 +83,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->ParentViewportId = value;
     */
 
-    /**
+     /**
      * Viewport flags to set when a window of this class owns a viewport.
      * This allows you to enforce OS decoration or task bar icon, override the defaults on a per-window basis.
      */
@@ -128,7 +131,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->ViewportFlagsOverrideSet = value;
     */
 
-    /**
+     /**
      * Viewport flags to clear when a window of this class owns a viewport.
      * This allows you to enforce OS decoration or task bar icon, override the defaults on a per-window basis.
      */
@@ -176,7 +179,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->ViewportFlagsOverrideClear = value;
     */
 
-    /**
+     /**
      * [EXPERIMENTAL] TabItem flags to set when a window of this class gets submitted into a dock node tab bar.
      * May use with ImGuiTabItemFlags_Leading or ImGuiTabItemFlags_Trailing.
      */
@@ -224,7 +227,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->TabItemFlagsOverrideSet = value;
     */
 
-    /**
+     /**
      * [EXPERIMENTAL] Dock node flags to set when a window of this class is hosted by a dock node (it doesn't have to be selected!)
      */
     public int getDockNodeFlagsOverrideSet() {
@@ -267,7 +270,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->DockNodeFlagsOverrideSet = value;
     */
 
-    /**
+     /**
      * Set to true to enforce single floating windows of this class always having their own docking node
      * (equivalent of setting the global io.ConfigDockingAlwaysTabBar)
      */
@@ -291,7 +294,7 @@ public final class ImGuiWindowClass extends ImGuiStructDestroyable {
         THIS->DockingAlwaysTabBar = value;
     */
 
-    /**
+     /**
      * Set to true to allow windows of this class to be docked/merged with an unclassed window.
      */
     public boolean getDockingAllowUnclassed() {

--- a/imgui-binding/src/generated/java/imgui/extension/imguiknobs/ImGuiKnobs.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguiknobs/ImGuiKnobs.java
@@ -1,5 +1,8 @@
 package imgui.extension.imguiknobs;
 
+
+
+
 import imgui.type.ImFloat;
 import imgui.type.ImInt;
 
@@ -7,6 +10,7 @@ import imgui.type.ImInt;
  * ImGuiKnobs extension for ImGui
  * Repo: https://github.com/altschuler/imgui-knobs
  */
+
 public final class ImGuiKnobs {
     private ImGuiKnobs() {
     }
@@ -15,7 +19,7 @@ public final class ImGuiKnobs {
         #include "_imguiknobs.h"
      */
 
-    /**
+     /**
      * Create a knob with float values
      *
      * @param label
@@ -513,7 +517,7 @@ public final class ImGuiKnobs {
         return _result;
     */
 
-    /**
+     /**
      * Create a knob with int values
      *
      * @param label

--- a/imgui-binding/src/generated/java/imgui/extension/imguiknobs/flag/ImGuiKnobFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguiknobs/flag/ImGuiKnobFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.imguiknobs.flag;
 
 
+
+
+
 public final class ImGuiKnobFlags {
     private ImGuiKnobFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imguiknobs/flag/ImGuiKnobVariant.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguiknobs/flag/ImGuiKnobVariant.java
@@ -1,6 +1,9 @@
 package imgui.extension.imguiknobs.flag;
 
 
+
+
+
 public final class ImGuiKnobVariant {
     private ImGuiKnobVariant() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imguizmo/ImGuizmo.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguizmo/ImGuizmo.java
@@ -2,7 +2,12 @@ package imgui.extension.imguizmo;
 
 import imgui.ImDrawList;
 import imgui.ImVec2;
+
+
+
+
 import imgui.internal.ImGuiContext;
+
 
 public final class ImGuizmo {
     private ImGuizmo() {
@@ -12,7 +17,7 @@ public final class ImGuizmo {
         #include "_imguizmo.h"
      */
 
-    /**
+     /**
      * Call inside your own window and before Manipulate() in order to draw gizmo to that window.
      * Or pass a specific ImDrawList to draw to (e.g. ImGui::GetForegroundDrawList()).
      */
@@ -36,7 +41,7 @@ public final class ImGuizmo {
         ImGuizmo::SetDrawlist(reinterpret_cast<ImDrawList*>(drawList));
     */
 
-    /**
+     /**
      * Call BeginFrame right after ImGui_XXXX_NewFrame();
      */
     public static void beginFrame() {
@@ -47,7 +52,7 @@ public final class ImGuizmo {
         ImGuizmo::BeginFrame();
     */
 
-    /**
+     /**
      * This is necessary because when imguizmo is compiled into a dll, and imgui into another
      * Globals are not shared between them.
      * More details at https://stackoverflow.com/questions/19373061/what-happens-to-global-and-static-variables-in-a-shared-library-when-it-is-dynam
@@ -61,7 +66,7 @@ public final class ImGuizmo {
         ImGuizmo::SetImGuiContext(reinterpret_cast<ImGuiContext*>(ctx));
     */
 
-    /**
+     /**
      * Return true if mouse cursor is over any gizmo control (axis, plan or screen component)
      */
     public static boolean isOver() {
@@ -72,7 +77,7 @@ public final class ImGuizmo {
         return ImGuizmo::IsOver();
     */
 
-    /**
+     /**
      * Return true if mouse IsOver or if the gizmo is in moving state
      */
     public static boolean isUsing() {
@@ -83,7 +88,7 @@ public final class ImGuizmo {
         return ImGuizmo::IsUsing();
     */
 
-    /**
+     /**
      * Enable/disable the gizmo. Stay in the state until next call to Enable.
      * Gizmo is rendered with gray half transparent color when disabled
      */
@@ -95,7 +100,7 @@ public final class ImGuizmo {
         ImGuizmo::Enable(enable);
     */
 
-    /**
+     /**
      * Helper function for manually editing Translation/Rotation/Scale with an input float.
      * Translation, Rotation and Scale float points to 3 floats each.
      * Angles are in degrees (more suitable for human editing).
@@ -126,7 +131,7 @@ public final class ImGuizmo {
         if (scale != NULL) env->ReleasePrimitiveArrayCritical(obj_scale, scale, JNI_FALSE);
     */
 
-    /**
+     /**
      * Helper function for manually editing Translation/Rotation/Scale with an input float.
      * Translation, Rotation and Scale float points to 3 floats each.
      * Angles are in degrees (more suitable for human editing).
@@ -157,7 +162,7 @@ public final class ImGuizmo {
         if (matrix != NULL) env->ReleasePrimitiveArrayCritical(obj_matrix, matrix, JNI_FALSE);
     */
 
-    /**
+     /**
      * This will set the rect position.
      *
      * @param x
@@ -177,7 +182,7 @@ public final class ImGuizmo {
         ImGuizmo::SetRect(x, y, width, height);
     */
 
-    /**
+     /**
      * Making sure if we're set to ortho or not.
      */
     public static void setOrthographic(final boolean isOrthographic) {
@@ -188,7 +193,7 @@ public final class ImGuizmo {
         ImGuizmo::SetOrthographic(isOrthographic);
     */
 
-    /**
+     /**
      * Drawing an arbitrary cube in the world.
      *
      * @param view
@@ -212,7 +217,7 @@ public final class ImGuizmo {
         if (matrices != NULL) env->ReleasePrimitiveArrayCritical(obj_matrices, matrices, JNI_FALSE);
     */
 
-    /**
+     /**
      * Drawing an arbitrary cube in the world.
      *
      * @param view
@@ -259,7 +264,7 @@ public final class ImGuizmo {
         drawCubes(view, projection, cubeMatrices, cubeMatrices.length);
     }
 
-    /**
+     /**
      * Drawing a grid to the world (should only be used for debugging purposes).
      *
      * @param view
@@ -285,7 +290,7 @@ public final class ImGuizmo {
         if (matrix != NULL) env->ReleasePrimitiveArrayCritical(obj_matrix, matrix, JNI_FALSE);
     */
 
-    /**
+     /**
      * Manipulating the given model matrix with delta matrix
      *
      * @param view
@@ -465,7 +470,7 @@ public final class ImGuizmo {
         if (boundsSnap != NULL) env->ReleasePrimitiveArrayCritical(obj_boundsSnap, boundsSnap, JNI_FALSE);
     */
 
-    /**
+     /**
      * Manipulating the view
      *
      * @param view
@@ -497,7 +502,7 @@ public final class ImGuizmo {
         if (view != NULL) env->ReleasePrimitiveArrayCritical(obj_view, view, JNI_FALSE);
     */
 
-    /**
+     /**
      * This will update the current id
      */
     public static void setID(final int id) {
@@ -508,7 +513,7 @@ public final class ImGuizmo {
         ImGuizmo::SetID(id);
     */
 
-    /**
+     /**
      * Return true if the cursor is over the operation's gizmo
      */
     public static boolean isOver(final int operation) {
@@ -527,7 +532,7 @@ public final class ImGuizmo {
         ImGuizmo::SetGizmoSizeClipSpace(value);
     */
 
-    /**
+     /**
      * Allow axis to flip.
      * When true (default), the guizmo axis flip for better visibility.
      * When false, they always stay along the positive world/local axis.

--- a/imgui-binding/src/generated/java/imgui/extension/imguizmo/flag/Mode.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguizmo/flag/Mode.java
@@ -1,6 +1,9 @@
 package imgui.extension.imguizmo.flag;
 
 
+
+
+
 public final class Mode {
     private Mode() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imguizmo/flag/Operation.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imguizmo/flag/Operation.java
@@ -1,11 +1,14 @@
 package imgui.extension.imguizmo.flag;
 
 
+
+
 /**
  * Needs view and projection matrices.
  * Matrix parameter is the source matrix (where will be gizmo be drawn) and might be transformed by the function. Return deltaMatrix is optional.
  * Translation is applied in world space.
  */
+
 public final class Operation {
     private Operation() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodes.java
@@ -1,6 +1,11 @@
 package imgui.extension.imnodes;
 
 import imgui.ImVec2;
+
+
+
+
+
 import imgui.internal.ImGuiContext;
 import imgui.type.ImBoolean;
 import imgui.type.ImInt;
@@ -11,6 +16,7 @@ import imgui.type.ImInt;
  * <p>
  * Refer to the library's Github page for examples and support
  */
+
 public final class ImNodes {
     private ImNodes() {
     }
@@ -159,7 +165,7 @@ public final class ImNodes {
         return (uintptr_t)&ImNodes::GetIO();
     */
 
-    private static final ImNodesStyle _GETSTYLE_1 = new ImNodesStyle(0);
+     private static final ImNodesStyle _GETSTYLE_1 = new ImNodesStyle(0);
 
     /**
      * Returns the global style struct. See the struct declaration for default values.
@@ -223,7 +229,7 @@ public final class ImNodes {
         ImNodes::StyleColorsLight(reinterpret_cast<ImNodesStyle*>(style));
     */
 
-    /**
+     /**
      * The top-level function call. Call this before calling BeginNode/EndNode. Calling this function
      * will result the node editor grid workspace being rendered.
      */
@@ -243,7 +249,7 @@ public final class ImNodes {
         ImNodes::EndNodeEditor();
     */
 
-    /**
+     /**
      * Add a navigable minimap to the editor; call before EndNodeEditor after all nodes and links have been specified
      * // TODO: add callback
      */
@@ -279,7 +285,7 @@ public final class ImNodes {
         ImNodes::MiniMap(miniMapSizeFraction, static_cast<ImNodesMiniMapLocation>(miniMapLocation));
     */
 
-    /**
+     /**
      * Use PushColorStyle and PopColorStyle to modify ImNodesColorStyle mid-frame.
      */
     public static void pushColorStyle(final int item, final int color) {
@@ -373,7 +379,7 @@ public final class ImNodes {
         return ImNodes::GetNodeDimensions(id).y;
     */
 
-    /**
+     /**
      * Place your node title bar content (such as the node title, using ImGui::Text) between the
      * following function calls. These functions have to be called before adding any attributes, or the
      * layout of the node will be incorrect.
@@ -403,7 +409,7 @@ public final class ImNodes {
     //
     // Each attribute id must be unique.
 
-    /**
+     /**
      * Create an input attribute block. The pin is rendered on left side.
      */
     public static void beginInputAttribute(final int id) {
@@ -435,7 +441,7 @@ public final class ImNodes {
         ImNodes::EndInputAttribute();
     */
 
-    /**
+     /**
      * Create an output attribute block. The pin is rendered on the right side.
      */
     public static void beginOutputAttribute(final int id) {
@@ -465,7 +471,7 @@ public final class ImNodes {
         ImNodes::EndOutputAttribute();
     */
 
-    /**
+     /**
      * Create a static attribute block. A static attribute has no pin, and therefore can't be linked to
      * anything. However, you can still use IsAttributeActive() and IsAnyAttributeActive() to check for
      * attribute activity.
@@ -486,7 +492,7 @@ public final class ImNodes {
         ImNodes::EndStaticAttribute();
     */
 
-    /**
+     /**
      * Push a single AttributeFlags value. By default, only AttributeFlags_None is set.
      */
     public static void pushAttributeFlag(final int flag) {
@@ -505,7 +511,7 @@ public final class ImNodes {
         ImNodes::PopAttributeFlag();
     */
 
-    /**
+     /**
      * Render a link between attributes.
      * The attributes ids used here must match the ids used in Begin(Input|Output)Attribute function
      * calls. The order of source and target doesn't make a difference for rendering the link.
@@ -518,7 +524,7 @@ public final class ImNodes {
         ImNodes::Link(id, source, target);
     */
 
-    /**
+     /**
      * Enable or disable the ability to click and drag a specific node.
      */
     public static void setNodeDraggable(final int nodeId, final boolean draggable) {
@@ -666,7 +672,7 @@ public final class ImNodes {
         return ImNodes::GetNodeGridSpacePos(nodeId).y;
     */
 
-    /**
+     /**
      * Enable or disable grid snapping.
      */
     public static void snapNodeToGrid(final int nodeId) {
@@ -677,7 +683,7 @@ public final class ImNodes {
         ImNodes::SnapNodeToGrid(nodeId);
     */
 
-    /**
+     /**
      * Returns true if the current node editor canvas is being hovered over by the mouse, and is not
      * blocked by any other windows.
      */
@@ -757,7 +763,7 @@ public final class ImNodes {
         return ImNodes::IsPinHovered(&i) ? i : -1;
     */
 
-    /**
+     /**
      * Use The following two functions to query the number of selected nodes or links in the current
      * editor. Use after calling EndNodeEditor().
      */
@@ -777,7 +783,7 @@ public final class ImNodes {
         return ImNodes::NumSelectedLinks();
     */
 
-    /**
+     /**
      * Get the selected node/link ids. The pointer argument should point to an integer array with at
      * least as many elements as the respective NumSelectedNodes/NumSelectedLinks function call
      * returned.
@@ -792,7 +798,7 @@ public final class ImNodes {
         if (nodeIds != NULL) env->ReleasePrimitiveArrayCritical(obj_nodeIds, nodeIds, JNI_FALSE);
     */
 
-    /**
+     /**
      * Get the selected node/link ids. The pointer argument should point to an integer array with at
      * least as many elements as the respective NumSelectedNodes/NumSelectedLinks function call
      * returned.
@@ -807,7 +813,7 @@ public final class ImNodes {
         if (linkIds != NULL) env->ReleasePrimitiveArrayCritical(obj_linkIds, linkIds, JNI_FALSE);
     */
 
-    /**
+     /**
      * Clears the list of selected nodes/links. Useful if you want to delete a selected node or link.
      */
     public static void clearNodeSelection() {
@@ -818,7 +824,7 @@ public final class ImNodes {
         ImNodes::ClearNodeSelection();
     */
 
-    /**
+     /**
      * Clears the list of selected nodes/links. Useful if you want to delete a selected node or link.
      */
     public static void clearLinkSelection() {
@@ -829,7 +835,7 @@ public final class ImNodes {
         ImNodes::ClearLinkSelection();
     */
 
-    /**
+     /**
      * Manually select a node or link.
      */
     public static void selectNode(final int nodeId) {
@@ -880,7 +886,7 @@ public final class ImNodes {
         return ImNodes::IsLinkSelected(linkId);
     */
 
-    /**
+     /**
      * Was the previous attribute active? This will continuously return true while the left mouse button
      * is being pressed over the UI content of the attribute.
      */
@@ -924,7 +930,7 @@ public final class ImNodes {
     // Use the following functions to query a change of state for an existing link, or new link. Call
     // these after EndNodeEditor().
 
-    /**
+     /**
      * Did the user start dragging a new link from a pin?
      */
     public static boolean isLinkStarted(final ImInt startedAtAttributeId) {
@@ -938,7 +944,7 @@ public final class ImNodes {
         return _result;
     */
 
-    /**
+     /**
      * Did the user drop the dragged link before attaching it to a pin?
      * There are two different kinds of situations to consider when handling this event:
      * 1) a link which is created at a pin and then dropped
@@ -1008,7 +1014,7 @@ public final class ImNodes {
         return ImNodes::IsLinkDropped(NULL, includingDetachedLinks);
     */
 
-    /**
+     /**
      * Did the user finish creating a new link?
      */
     public static boolean isLinkCreated(final ImInt startedAtAttributeId, final ImInt endedAtAttributeId) {
@@ -1042,7 +1048,7 @@ public final class ImNodes {
         return _result;
     */
 
-    /**
+     /**
      * Did the user finish creating a new link?
      */
     public static boolean isLinkCreated(final ImInt startedAtNodeId, final ImInt startedAtAttributeId, final ImInt endedAtNodeId, final ImInt endedAtAttributeId) {
@@ -1084,7 +1090,7 @@ public final class ImNodes {
         return _result;
     */
 
-    /**
+     /**
      * Was an existing link detached from a pin by the user? The detached link's id is assigned to the
      * output argument link_id.
      */

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodesIO.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodesIO.java
@@ -2,6 +2,9 @@ package imgui.extension.imnodes;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 public final class ImNodesIO extends ImGuiStruct {
     public ImNodesIO(final long ptr) {
         super(ptr);
@@ -12,7 +15,7 @@ public final class ImNodesIO extends ImGuiStruct {
         #define THIS ((ImNodesIO*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Holding alt mouse button pans the node area, by default middle mouse button will be used
      * Set based on ImGuiMouseButton values
      */
@@ -36,7 +39,7 @@ public final class ImNodesIO extends ImGuiStruct {
         THIS->AltMouseButton = value;
     */
 
-    /**
+     /**
      * Panning speed when dragging an element and mouse is outside the main editor view.
      */
     public float getAutoPanningSpeed() {

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodesStyle.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/ImNodesStyle.java
@@ -4,6 +4,10 @@ import imgui.ImVec2;
 import imgui.ImVec4;
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
 public final class ImNodesStyle extends ImGuiStruct {
     public ImNodesStyle(final long ptr) {
         super(ptr);
@@ -153,7 +157,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->LinkHoverDistance = value;
     */
 
-    /**
+     /**
      * The circle radius used when the pin shape is either PinShape_Circle or PinShape_CircleFilled.
      */
     public float getPinCircleRadius() {
@@ -175,7 +179,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinCircleRadius = value;
     */
 
-    /**
+     /**
      * The quad side length used when the shape is either PinShape_Quad or PinShape_QuadFilled.
      */
     public float getPinQuadSideLength() {
@@ -197,7 +201,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinQuadSideLength = value;
     */
 
-    /**
+     /**
      * The equilateral triangle side length used when the pin shape is either PinShape_Triangle or PinShape_TriangleFilled.
      */
     public float getPinTriangleSideLength() {
@@ -219,7 +223,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinTriangleSideLength = value;
     */
 
-    /**
+     /**
      * The thickness of the line used when the pin shape is not filled.
      */
     public float getPinLineThickness() {
@@ -241,7 +245,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinLineThickness = value;
     */
 
-    /**
+     /**
      * The radius from the pin's center position inside of which it is detected as being hovered over.
      */
     public float getPinHoverRadius() {
@@ -263,7 +267,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinHoverRadius = value;
     */
 
-    /**
+     /**
      * Offsets the pins' positions from the edge of the node to the outside of the node.
      */
     public float getPinOffset() {
@@ -285,7 +289,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->PinOffset = value;
     */
 
-    /**
+     /**
      * Mini-map padding size between mini-map edge and mini-map content.
      */
     public ImVec2 getMiniMapPadding() {
@@ -346,7 +350,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->MiniMapPadding = value;
     */
 
-    /**
+     /**
      * Mini-map offset from the screen side.
      */
     public ImVec2 getMiniMapOffset() {
@@ -407,7 +411,7 @@ public final class ImNodesStyle extends ImGuiStruct {
         THIS->MiniMapOffset = value;
     */
 
-    /**
+     /**
      * By default, ImNodesStyleFlags_NodeOutline and ImNodesStyleFlags_Gridlines are enabled.
      */
     public int getFlags() {

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesAttributeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesAttributeFlags.java
@@ -1,9 +1,12 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
 /**
  * This enum controls the way the attribute pins behave.
  */
+
 public final class ImNodesAttributeFlags {
     private ImNodesAttributeFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesCol.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesCol.java
@@ -1,6 +1,9 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
+
 public final class ImNodesCol {
     private ImNodesCol() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesMiniMapLocation.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesMiniMapLocation.java
@@ -1,9 +1,12 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
 /**
  * This enum controls the minimap's location.
  */
+
 public final class ImNodesMiniMapLocation {
     private ImNodesMiniMapLocation() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesPinShape.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesPinShape.java
@@ -1,9 +1,12 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
 /**
  * This enum controls the way attribute pins look.
  */
+
 public final class ImNodesPinShape {
     private ImNodesPinShape() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
+
 public final class ImNodesStyleFlags {
     private ImNodesStyleFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/extension/imnodes/flag/ImNodesStyleVar.java
@@ -1,6 +1,9 @@
 package imgui.extension.imnodes.flag;
 
 
+
+
+
 public final class ImNodesStyleVar {
     private ImNodesStyleVar() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlot.java
@@ -3,10 +3,17 @@ package imgui.extension.implot;
 import imgui.ImDrawList;
 import imgui.ImVec2;
 import imgui.ImVec4;
+
+
+
+
+
+
 import imgui.internal.ImGuiContext;
 import imgui.type.ImBoolean;
 import imgui.type.ImDouble;
 import imgui.type.ImFloat;
+
 
 public final class ImPlot {
     private ImPlot() {
@@ -20,7 +27,7 @@ public final class ImPlot {
     // [SECTION] Contexts
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Creates a new ImPlot context. Call this after ImGui.createContext().
      */
     public static ImPlotContext createContext() {
@@ -31,7 +38,7 @@ public final class ImPlot {
         return (uintptr_t)ImPlot::CreateContext();
     */
 
-    /**
+     /**
      * Destroys an ImPlot context. Call this before ImGui.destroyContext(). NULL = destroy current context.
      */
     public static void destroyContext() {
@@ -53,7 +60,7 @@ public final class ImPlot {
         ImPlot::DestroyContext(reinterpret_cast<ImPlotContext*>(ctx));
     */
 
-    /**
+     /**
      * Returns the current ImPlot context. NULL if no context has ben set.
      */
     public static ImPlotContext getCurrentContext() {
@@ -64,7 +71,7 @@ public final class ImPlot {
         return (uintptr_t)ImPlot::GetCurrentContext();
     */
 
-    /**
+     /**
      * Sets the current ImPlot context.
      */
     public static void setCurrentContext(final ImPlotContext ctx) {
@@ -158,7 +165,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndPlot() if beginPlot() returns true! Typically called at the end
      * of an if statement conditioned on BeginPlot(). See example in beginPlot().
      */
@@ -310,7 +317,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Only call EndSubplots() if BeginSubplots() returns true! Typically called at the end
      * of an if statement conditioned on BeginSublots(). See example above.
      */
@@ -351,7 +358,7 @@ public final class ImPlot {
     //   call it yourself, then the first subsequent plotting or utility function will
     //   call it for you.
 
-    /**
+     /**
      * Enables an axis or sets the label and/or flags for an existing axis.
      * Leave `label` as NULL for no label.
      */
@@ -403,7 +410,7 @@ public final class ImPlot {
         ImPlot::SetupAxis(axis, NULL, flags);
     */
 
-    /**
+     /**
      * Sets an axis range limits. If ImPlotCond_Always is used, the axes limits will be locked.
      * Inversion with {@code v_min > v_max} is not supported; use SetupAxisLimits instead.
      */
@@ -427,7 +434,7 @@ public final class ImPlot {
         ImPlot::SetupAxisLimits(axis, vMin, vMax, cond);
     */
 
-    /**
+     /**
      * Links an axis range limits to external values. Set to NULL for no linkage.
      * The pointer data must remain valid until EndPlot.
      */
@@ -443,7 +450,7 @@ public final class ImPlot {
         if (linkMax != NULL) env->ReleasePrimitiveArrayCritical(obj_linkMax, linkMax, JNI_FALSE);
     */
 
-    /**
+     /**
      * Sets the format of numeric axis labels via formatter specifier (default="%g").
      * Formatted values will be double (i.e. use %f).
      */
@@ -459,7 +466,7 @@ public final class ImPlot {
 
     // TODO: support ImPlotFormatter
 
-    /**
+     /**
      * Sets an axis' ticks and optionally the labels. To keep the default ticks,
      * set `keepDefault=true`.
      */
@@ -535,7 +542,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Sets an axis' ticks and optionally the labels for the next plot.
      * To keep the default ticks, set `keepDefault=true`.
      */
@@ -603,7 +610,7 @@ public final class ImPlot {
         ImPlot::SetupAxisTicks(axis, vMin, vMax, nTicks, NULL, keepDefault);
     */
 
-    /**
+     /**
      * Sets an axis' scale using built-in options.
      */
     public static void setupAxisScale(final int axis, final int scale) {
@@ -614,7 +621,7 @@ public final class ImPlot {
         ImPlot::SetupAxisScale(axis, scale);
     */
 
-    /**
+     /**
      * Sets an axis' limits constraints.
      */
     public static void setupAxisLimitsConstraints(final int axis, final double vMin, final double vMax) {
@@ -625,7 +632,7 @@ public final class ImPlot {
         ImPlot::SetupAxisLimitsConstraints(axis, vMin, vMax);
     */
 
-    /**
+     /**
      * Sets an axis' zoom constraints.
      */
     public static void setupAxisZoomConstraints(final int axis, final double vMin, final double vMax) {
@@ -636,7 +643,7 @@ public final class ImPlot {
         ImPlot::SetupAxisZoomConstraints(axis, vMin, vMax);
     */
 
-    /**
+     /**
      * Sets the label and/or flags for primary X and Y axes (shorthand for two calls to SetupAxis).
      */
     public static void setupAxes(final String xLabel, final String yLabel) {
@@ -681,7 +688,7 @@ public final class ImPlot {
         if (yLabel != NULL) env->ReleaseStringUTFChars(obj_yLabel, yLabel);
     */
 
-    /**
+     /**
      * Sets the primary X and Y axes range limits. If ImPlotCond_Always is used,
      * the axes limits will be locked (shorthand for two calls to SetupAxisLimits).
      */
@@ -705,7 +712,7 @@ public final class ImPlot {
         ImPlot::SetupAxesLimits(xMin, xMax, yMin, yMax, cond);
     */
 
-    /**
+     /**
      * Sets up the plot legend.
      */
     public static void setupLegend(final int location) {
@@ -727,7 +734,7 @@ public final class ImPlot {
         ImPlot::SetupLegend(location, flags);
     */
 
-    /**
+     /**
      * Sets the location of the current plot's mouse position text (default = South|East).
      */
     public static void setupMouseText(final int location) {
@@ -749,7 +756,7 @@ public final class ImPlot {
         ImPlot::SetupMouseText(location, flags);
     */
 
-    /**
+     /**
      * Explicitly finalize plot setup. Once you call this, you cannot make any more
      * Setup calls for the current plot! Note that calling this function is OPTIONAL;
      * it will be called by the first subsequent setup-locking API call.
@@ -785,7 +792,7 @@ public final class ImPlot {
     // - You must still enable non-default axes with SetupAxis for these functions
     //   to work properly.
 
-    /**
+     /**
      * Sets an upcoming axis range limits. If ImPlotCond_Always is used, the axes limits will be locked.
      */
     public static void setNextAxisLimits(final int axis, final double vMin, final double vMax) {
@@ -807,7 +814,7 @@ public final class ImPlot {
         ImPlot::SetNextAxisLimits(axis, vMin, vMax, cond);
     */
 
-    /**
+     /**
      * Links an upcoming axis range limits to external values. Set to NULL for no linkage.
      * The pointer data must remain valid until EndPlot!
      */
@@ -823,7 +830,7 @@ public final class ImPlot {
         if (linkMax != NULL) env->ReleasePrimitiveArrayCritical(obj_linkMax, linkMax, JNI_FALSE);
     */
 
-    /**
+     /**
      * Set an upcoming axis to auto fit to its data.
      */
     public static void setNextAxisToFit(final int axis) {
@@ -834,7 +841,7 @@ public final class ImPlot {
         ImPlot::SetNextAxisToFit(axis);
     */
 
-    /**
+     /**
      * Sets the upcoming primary X and Y axes range limits. If ImPlotCond_Always is used,
      * the axes limits will be locked (shorthand for two calls to SetupAxisLimits).
      */
@@ -858,7 +865,7 @@ public final class ImPlot {
         ImPlot::SetNextAxesLimits(xMin, xMax, yMin, yMax, cond);
     */
 
-    /**
+     /**
      * Sets all upcoming axes to auto fit to their data.
      */
     public static void setNextAxesToFit() {
@@ -929,7 +936,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a standard 2D line plot.
      */
     public static void plotLine(final String labelId, final short[] values) {
@@ -1304,7 +1311,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a standard 2D line plot.
      */
     public static void plotLineV(final String labelId, final short[] values, final int count) {
@@ -1681,7 +1688,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a standard 2D line plot.
      */
     public static void plotLine(final String labelId, final short[] xs, final short[] ys) {
@@ -1851,7 +1858,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a standard 2D line plot.
      */
     public static void plotLineV(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -2108,7 +2115,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final short[] values) {
@@ -2483,7 +2490,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatterV(final String labelId, final short[] values, final int count) {
@@ -2860,7 +2867,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatter(final String labelId, final short[] xs, final short[] ys) {
@@ -3030,7 +3037,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
      */
     public static void plotScatterV(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -3287,7 +3294,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final short[] values) {
@@ -3662,7 +3669,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairsV(final String labelId, final short[] values, final int count) {
@@ -4039,7 +4046,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairs(final String labelId, final short[] xs, final short[] ys) {
@@ -4209,7 +4216,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a stairstep graph. The y value is continued constantly from every x position, i.e. the interval [x[i], x[i+1]) has the value y[i].
      */
     public static void plotStairsV(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -4466,7 +4473,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] values) {
@@ -4916,7 +4923,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShadedV(final String labelId, final short[] values, final int count) {
@@ -5368,7 +5375,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] xs, final short[] ys) {
@@ -5708,7 +5715,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShadedV(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -6050,7 +6057,7 @@ public final class ImPlot {
 
     // xs,ys1,ys2
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShaded(final String labelId, final short[] xs, final short[] ys1, final short[] ys2) {
@@ -6240,7 +6247,7 @@ public final class ImPlot {
         if (ys2 != NULL) env->ReleasePrimitiveArrayCritical(obj_ys2, ys2, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a shaded (filled) region between two lines, or a line and a horizontal reference. Set y_ref to +/-INFINITY for infinite fill extents.
      */
     public static void plotShadedV(final String labelId, final short[] xs, final short[] ys1, final short[] ys2, final int count) {
@@ -6527,7 +6534,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #xstart are in X units.
      */
     public static void plotBars(final String labelId, final short[] values) {
@@ -6902,7 +6909,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #xstart are in X units.
      */
     public static void plotBarsV(final String labelId, final short[] values, final int count) {
@@ -7279,7 +7286,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #xstart are in X units.
      */
     public static void plotBars(final String labelId, final short[] xs, final short[] ys) {
@@ -7534,7 +7541,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #xstart are in X units.
      */
     public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final double barWidth) {
@@ -7789,7 +7796,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a vertical bar graph. #bar_width and #xstart are in X units.
      */
     public static void plotBarsV(final String labelId, final short[] xs, final short[] ys, final int count, final double barWidth) {
@@ -8044,7 +8051,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
     public static void plotBarGroups(final String[] labelIds, final short[] values, final int groupCount) {
@@ -8504,7 +8511,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a group of vertical bars. #values is a row-major matrix with #item_count rows and #group_count cols. #label_ids should have #item_count elements.
      */
     public static void plotBarGroupsV(final String[] labelIds, final short[] values, final int itemCount, final int groupCount) {
@@ -8964,7 +8971,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] err) {
@@ -9249,7 +9256,7 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsV(final String labelId, final short[] xs, final short[] ys, final short[] err, final int count) {
@@ -9534,7 +9541,7 @@ public final class ImPlot {
         if (err != NULL) env->ReleasePrimitiveArrayCritical(obj_err, err, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBars(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos) {
@@ -9849,7 +9856,7 @@ public final class ImPlot {
         if (pos != NULL) env->ReleasePrimitiveArrayCritical(obj_pos, pos, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
      */
     public static void plotErrorBarsV(final String labelId, final short[] xs, final short[] ys, final short[] neg, final short[] pos, final int count) {
@@ -10166,7 +10173,7 @@ public final class ImPlot {
 
     // values
 
-    /**
+     /**
      * Plots vertical stems.
      */
     public static void plotStems(final String labelId, final short[] values) {
@@ -10616,7 +10623,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical stems.
      */
     public static void plotStemsV(final String labelId, final short[] values, final int count) {
@@ -11068,7 +11075,7 @@ public final class ImPlot {
 
     // xs,ys
 
-    /**
+     /**
      * Plots vertical stems.
      */
     public static void plotStems(final String labelId, final short[] xs, final short[] ys) {
@@ -11408,7 +11415,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots vertical stems.
      */
     public static void plotStemsV(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -11748,7 +11755,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     public static void plotInfLines(final String labelId, final short[] values) {
@@ -11973,7 +11980,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots infinite vertical or horizontal lines (e.g. for references or asymptotes).
      */
     public static void plotInfLinesV(final String labelId, final short[] values, final int count) {
@@ -12198,7 +12205,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
     public static void plotPieChart(final String[] labelIds, final short[] values, final double x, final double y, final double radius) {
@@ -12803,7 +12810,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a pie chart. If the sum of values{@code >}1 or normalize is true, each value will be normalized. Center and radius are in plot units. #label_fmt can be set to NULL for no labels.
      */
     public static void plotPieChartV(final String[] labelIds, final short[] values, final int count, final double x, final double y, final double radius) {
@@ -13408,7 +13415,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a 2D heatmap chart. Values are expected to be in row-major order. Leave #scale_min and scale_max both at 0 for automatic color scaling, or set them to a predefined range. #label_fmt can be set to NULL for no labels.
      */
     public static void plotHeatmap(final String labelId, final short[] values, final int rows, final int cols) {
@@ -14188,7 +14195,7 @@ public final class ImPlot {
         if (values != NULL) env->ReleasePrimitiveArrayCritical(obj_values, values, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
@@ -14953,7 +14960,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Plots a horizontal histogram. #bins can be a positive integer or an ImPlotBin_ method. If #cumulative is true, each bin contains its count plus the counts of all previous bins.
      * If #density is true, the PDF is visualized. If both are true, the CDF is visualized. If #range is left unspecified, the min/max of #values will be used as the range.
      * If #range is specified, outlier values outside of the range are not binned. However, outliers still count toward normalizing and cumulative counts unless #outliers is false. The largest bin count or density is returned.
@@ -15583,7 +15590,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
@@ -16273,7 +16280,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Plots two dimensional, bivariate histogram as a heatmap. #x_bins and #y_bins can be a positive integer or an ImPlotBin. If #density is true, the PDF is visualized.
      * If #range is left unspecified, the min/max of #xs an #ys will be used as the ranges. If #range is specified, outlier values outside of range are not binned.
      * However, outliers still count toward the normalizing count for density plots unless #outliers is false. The largest bin count or density is returned.
@@ -16963,7 +16970,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     public static void plotDigital(final String labelId, final short[] xs, final short[] ys) {
@@ -17218,7 +17225,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
      */
     public static void plotDigitalV(final String labelId, final short[] xs, final short[] ys, final int count) {
@@ -17473,7 +17480,7 @@ public final class ImPlot {
         if (ys != NULL) env->ReleasePrimitiveArrayCritical(obj_ys, ys, JNI_FALSE);
     */
 
-    /**
+     /**
      * Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinates (y-up) and #uv0/uv1 are in texture coordinates (y-down).
      */
     public static void plotImage(final String labelId, final long userTextureId, final ImPlotPoint boundsMin, final ImPlotPoint boundsMax) {
@@ -17610,7 +17617,7 @@ public final class ImPlot {
         if (labelId != NULL) env->ReleaseStringUTFChars(obj_labelId, labelId);
     */
 
-    /**
+     /**
      * Plots a centered text label at point x,y with an optional pixel offset. Text color can be changed with ImPlot::PushStyleColor(ImPlotCol_InlayText, ...).
      */
     public static void plotText(final String text, final double x, final double y) {
@@ -17678,7 +17685,7 @@ public final class ImPlot {
         if (text != NULL) env->ReleaseStringUTFChars(obj_text, text);
     */
 
-    /**
+     /**
      * Plots a dummy item (i.e. adds a legend entry colored by ImPlotCol_Line)
      */
     public static void plotDummy(final String labelID) {
@@ -17717,7 +17724,7 @@ public final class ImPlot {
     // Like the item plotting functions above, they apply to the current x and y
     // axes, which can be changed with `SetAxis/SetAxes`.
 
-    /**
+     /**
      * Shows a draggable point at x, y. `col` defaults to ImGuiCol_Text.
      */
     public static boolean dragPoint(final int id, final ImDouble x, final ImDouble y, final ImVec4 col) {
@@ -17813,7 +17820,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows a draggable vertical guide line at an x-value. `col` defaults to ImGuiCol_Text.
      */
     public static boolean dragLineX(final int id, final ImDouble x, final ImVec4 col) {
@@ -17901,7 +17908,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows a draggable horizontal guide line at a y-value. `col` defaults to ImGuiCol_Text.
      */
     public static boolean dragLineY(final int id, final ImDouble y, final ImVec4 col) {
@@ -17989,7 +17996,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows a draggable and resizeable rectangle.
      */
     public static boolean dragRect(final int id, final ImDouble xMin, final ImDouble yMin, final ImDouble xMax, final ImDouble yMax, final ImVec4 col) {
@@ -18045,7 +18052,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows an annotation callout at a chosen point. Clamping keeps annotations in the plot area.
      * Annotations are always rendered on top.
      */
@@ -18089,7 +18096,7 @@ public final class ImPlot {
         ImPlot::Annotation(x, y, col, pixOffset, clamp, round);
     */
 
-    /**
+     /**
      * Shows an annotation callout at a chosen point with formatted text.
      * Clamping keeps annotations in the plot area. Annotations are always rendered on top.
      */
@@ -18113,7 +18120,7 @@ public final class ImPlot {
         if (fmt != NULL) env->ReleaseStringUTFChars(obj_fmt, fmt);
     */
 
-    /**
+     /**
      * Shows a x-axis tag at the specified coordinate value.
      */
     public static void tagX(final double x, final ImVec4 col) {
@@ -18151,7 +18158,7 @@ public final class ImPlot {
         ImPlot::TagX(x, col, round);
     */
 
-    /**
+     /**
      * Shows a x-axis tag at the specified coordinate value with formatted text.
      */
     public static void tagX(final double x, final ImVec4 col, final String fmt) {
@@ -18172,7 +18179,7 @@ public final class ImPlot {
         if (fmt != NULL) env->ReleaseStringUTFChars(obj_fmt, fmt);
     */
 
-    /**
+     /**
      * Shows a y-axis tag at the specified coordinate value.
      */
     public static void tagY(final double y, final ImVec4 col) {
@@ -18210,7 +18217,7 @@ public final class ImPlot {
         ImPlot::TagY(y, col, round);
     */
 
-    /**
+     /**
      * Shows a y-axis tag at the specified coordinate value with formatted text.
      */
     public static void tagY(final double y, final ImVec4 col, final String fmt) {
@@ -18235,7 +18242,7 @@ public final class ImPlot {
     // [SECTION] Plot Utils
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Selects which axis will be used for subsequent plot elements.
      */
     public static void setAxis(final int axis) {
@@ -18246,7 +18253,7 @@ public final class ImPlot {
         ImPlot::SetAxis(axis);
     */
 
-    /**
+     /**
      * Selects which axes will be used for subsequent plot elements.
      */
     public static void setAxes(final int xAxis, final int yAxis) {
@@ -18257,7 +18264,7 @@ public final class ImPlot {
         ImPlot::SetAxes(xAxis, yAxis);
     */
 
-    /**
+     /**
      * Converts pixels to a position in the current plot's coordinate system.
      * Passing IMPLOT_AUTO uses the current axes.
      */
@@ -18380,7 +18387,7 @@ public final class ImPlot {
         Jni::ImPlotPointCpy(env, ImPlot::PixelsToPlot(pix, xAxis, yAxis), dst);
     */
 
-    /**
+     /**
      * Converts a position in the current plot's coordinate system to pixels.
      * Passing IMPLOT_AUTO uses the current axes.
      */
@@ -18572,7 +18579,7 @@ public final class ImPlot {
         return ImPlot::PlotToPixels(ImPlotPoint(pltX, pltY), xAxis, yAxis).y;
     */
 
-    /**
+     /**
      * Gets the current Plot position (top-left) in pixels.
      */
     public static ImVec2 getPlotPos() {
@@ -18614,7 +18621,7 @@ public final class ImPlot {
         return ImPlot::GetPlotPos().y;
     */
 
-    /**
+     /**
      * Gets the current Plot size in pixels.
      */
     public static ImVec2 getPlotSize() {
@@ -18656,7 +18663,7 @@ public final class ImPlot {
         return ImPlot::GetPlotSize().y;
     */
 
-    /**
+     /**
      * Returns the mouse position in x, y coordinates of the current plot.
      * Passing IMPLOT_AUTO uses the current axes.
      */
@@ -18722,7 +18729,7 @@ public final class ImPlot {
         Jni::ImPlotPointCpy(env, ImPlot::GetPlotMousePos(xAxis, yAxis), dst);
     */
 
-    /**
+     /**
      * Returns the current plot axis range.
      */
     public static ImPlotRect getPlotLimits() {
@@ -18782,7 +18789,7 @@ public final class ImPlot {
         Jni::ImPlotRectCpy(env, ImPlot::GetPlotLimits(xAxis, yAxis), dst);
     */
 
-    /**
+     /**
      * Returns true if the plot area in the current plot is hovered.
      */
     public static boolean isPlotHovered() {
@@ -18793,7 +18800,7 @@ public final class ImPlot {
         return ImPlot::IsPlotHovered();
     */
 
-    /**
+     /**
      * Returns true if the axis label area in the current plot is hovered.
      */
     public static boolean isAxisHovered(final int axis) {
@@ -18804,7 +18811,7 @@ public final class ImPlot {
         return ImPlot::IsAxisHovered(axis);
     */
 
-    /**
+     /**
      * Returns true if the bounding frame of a subplot is hovered.
      */
     public static boolean isSubplotsHovered() {
@@ -18815,7 +18822,7 @@ public final class ImPlot {
         return ImPlot::IsSubplotsHovered();
     */
 
-    /**
+     /**
      * Returns true if the current plot is being box selected.
      */
     public static boolean isPlotSelected() {
@@ -18826,7 +18833,7 @@ public final class ImPlot {
         return ImPlot::IsPlotSelected();
     */
 
-    /**
+     /**
      * Returns the current plot box selection bounds.
      * Passing IMPLOT_AUTO uses the current axes.
      */
@@ -18892,7 +18899,7 @@ public final class ImPlot {
         Jni::ImPlotRectCpy(env, ImPlot::GetPlotSelection(xAxis, yAxis), dst);
     */
 
-    /**
+     /**
      * Cancels the current plot box selection.
      */
     public static void cancelPlotSelection() {
@@ -18903,7 +18910,7 @@ public final class ImPlot {
         ImPlot::CancelPlotSelection();
     */
 
-    /**
+     /**
      * Hides or shows the next plot item (i.e. as if it were toggled from the legend).
      * Use ImPlotCond_Always if you need to forcefully set this every frame.
      */
@@ -18956,7 +18963,7 @@ public final class ImPlot {
     // accomplish the same behaviour by default. The functions below offer lower
     // level control of plot alignment.
 
-    /**
+     /**
      * Aligns axis padding over multiple plots in a single row or column.
      * `group_id` must be unique. If this function returns true, EndAlignedPlots() must be called.
      */
@@ -18986,7 +18993,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Ends aligned plots. Only call EndAlignedPlots() if BeginAlignedPlots() returns true.
      */
     public static void endAlignedPlots() {
@@ -19001,7 +19008,7 @@ public final class ImPlot {
     // [SECTION] Legend Utils
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Begins a popup for a legend entry.
      */
     public static boolean beginLegendPopup(final String labelId) {
@@ -19029,7 +19036,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Ends a popup for a legend entry.
      */
     public static void endLegendPopup() {
@@ -19040,7 +19047,7 @@ public final class ImPlot {
         ImPlot::EndLegendPopup();
     */
 
-    /**
+     /**
      * Returns true if a plot item legend entry is hovered.
      */
     public static boolean isLegendEntryHovered(final String labelId) {
@@ -19058,7 +19065,7 @@ public final class ImPlot {
     // [SECTION] Drag and Drop
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Turns the current plot's plotting area into a drag and drop target.
      * Don't forget to call EndDragDropTarget!
      */
@@ -19070,7 +19077,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropTargetPlot();
     */
 
-    /**
+     /**
      * Turns the current plot's X-axis into a drag and drop target.
      * Don't forget to call EndDragDropTarget!
      */
@@ -19082,7 +19089,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropTargetAxis(axis);
     */
 
-    /**
+     /**
      * Turns the current plot's legend into a drag and drop target.
      * Don't forget to call EndDragDropTarget!
      */
@@ -19094,7 +19101,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropTargetLegend();
     */
 
-    /**
+     /**
      * Ends a drag and drop target (currently just an alias for ImGui::EndDragDropTarget).
      */
     public static void endDragDropTarget() {
@@ -19108,7 +19115,7 @@ public final class ImPlot {
     // NB: By default, plot and axes drag and drop *sources* require holding the Ctrl modifier to initiate the drag.
     // You can change the modifier if desired. If ImGuiKeyModFlags_None is provided, the axes will be locked from panning.
 
-    /**
+     /**
      * Turns the current plot's plotting area into a drag and drop source.
      * You must hold Ctrl. Don't forget to call EndDragDropSource!
      */
@@ -19132,7 +19139,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropSourcePlot(flags);
     */
 
-    /**
+     /**
      * Turns the current plot's X-axis into a drag and drop source.
      * You must hold Ctrl. Don't forget to call EndDragDropSource!
      */
@@ -19156,7 +19163,7 @@ public final class ImPlot {
         return ImPlot::BeginDragDropSourceAxis(axis, flags);
     */
 
-    /**
+     /**
      * Turns an item in the current plot's legend into a drag and drop source.
      * Don't forget to call EndDragDropSource!
      */
@@ -19186,7 +19193,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Ends a drag and drop source (currently just an alias for ImGui::EndDragDropSource).
      */
     public static void endDragDropSource() {
@@ -19230,7 +19237,7 @@ public final class ImPlot {
     //        manually set these colors to whatever you like, and further can Push/Pop
     //        them around individual plots for plot-specific styling (e.g. coloring axes).
 
-    private static final ImPlotStyle _GETSTYLE_1 = new ImPlotStyle(0);
+     private static final ImPlotStyle _GETSTYLE_1 = new ImPlotStyle(0);
 
     /**
      * Provides access to plot style structure for permanant modifications to colors, sizes, etc.
@@ -19244,7 +19251,7 @@ public final class ImPlot {
         return (uintptr_t)&ImPlot::GetStyle();
     */
 
-    /**
+     /**
      * Style plot colors for current ImGui style (default).
      */
     public static void styleColorsAuto() {
@@ -19266,7 +19273,7 @@ public final class ImPlot {
         ImPlot::StyleColorsAuto(reinterpret_cast<ImPlotStyle*>(dst));
     */
 
-    /**
+     /**
      * Style plot colors for ImGui "Classic".
      */
     public static void styleColorsClassic() {
@@ -19288,7 +19295,7 @@ public final class ImPlot {
         ImPlot::StyleColorsClassic(reinterpret_cast<ImPlotStyle*>(dst));
     */
 
-    /**
+     /**
      * Style plot colors for ImGui "Dark".
      */
     public static void styleColorsDark() {
@@ -19310,7 +19317,7 @@ public final class ImPlot {
         ImPlot::StyleColorsDark(reinterpret_cast<ImPlotStyle*>(dst));
     */
 
-    /**
+     /**
      * Style plot colors for ImGui "Light".
      */
     public static void styleColorsLight() {
@@ -19343,7 +19350,7 @@ public final class ImPlot {
         ImPlot::PushStyleColor(idx, col);
     */
 
-    /**
+     /**
      * Temporarily modify a style color. Don't forget to call PopStyleColor!
      */
     public static void pushStyleColor(final int idx, final int col) {
@@ -19354,7 +19361,7 @@ public final class ImPlot {
         ImPlot::PushStyleColor(idx, static_cast<ImU32>(col));
     */
 
-    /**
+     /**
      * Temporarily modify a style color. Don't forget to call PopStyleColor!
      */
     public static void pushStyleColor(final int idx, final ImVec4 col) {
@@ -19389,7 +19396,7 @@ public final class ImPlot {
         ImPlot::PopStyleColor(count);
     */
 
-    /**
+     /**
      * Temporarily modify a style variable of float type. Don't forget to call PopStyleVar!
      */
     public static void pushStyleVar(final int idx, final float val) {
@@ -19400,7 +19407,7 @@ public final class ImPlot {
         ImPlot::PushStyleVar(idx, static_cast<float>(val));
     */
 
-    /**
+     /**
      * Temporarily modify a style variable of int type. Don't forget to call PopStyleVar!
      */
     public static void pushStyleVar(final int idx, final int val) {
@@ -19411,7 +19418,7 @@ public final class ImPlot {
         ImPlot::PushStyleVar(idx, static_cast<int>(val));
     */
 
-    /**
+     /**
      * Temporarily modify a style variable of ImVec2 type. Don't forget to call PopStyleVar!
      */
     public static void pushStyleVar(final int idx, final ImVec2 val) {
@@ -19430,7 +19437,7 @@ public final class ImPlot {
         ImPlot::PushStyleVar(idx, val);
     */
 
-    /**
+     /**
      * Undo temporary style variable modification(s). Undo multiple pushes at once by increasing count.
      */
     public static void popStyleVar() {
@@ -19452,7 +19459,7 @@ public final class ImPlot {
         ImPlot::PopStyleVar(count);
     */
 
-    /**
+     /**
      * Set the line color and weight for the next item only.
      */
     public static void setNextLineStyle() {
@@ -19512,7 +19519,7 @@ public final class ImPlot {
         ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, weight);
     */
 
-    /**
+     /**
      * Set the fill color for the next item only.
      */
     public static void setNextFillStyle() {
@@ -19572,7 +19579,7 @@ public final class ImPlot {
         ImPlot::SetNextFillStyle(IMPLOT_AUTO_COL, alphaMod);
     */
 
-    /**
+     /**
      * Set the marker style for the next item only.
      */
     public static void setNextMarkerStyle() {
@@ -19683,7 +19690,7 @@ public final class ImPlot {
         ImPlot::SetNextMarkerStyle(marker, size, fill, IMPLOT_AUTO, outline);
     */
 
-    /**
+     /**
      * Set the error bar style for the next item only.
      */
     public static void setNextErrorBarStyle() {
@@ -19762,7 +19769,7 @@ public final class ImPlot {
         ImPlot::SetNextErrorBarStyle(IMPLOT_AUTO_COL, size, weight);
     */
 
-    /**
+     /**
      * Gets the last item primary color (i.e. its legend icon color)
      */
     public static ImVec4 getLastItemColor() {
@@ -19826,7 +19833,7 @@ public final class ImPlot {
         return ImPlot::GetLastItemColor().w;
     */
 
-    /**
+     /**
      * Returns the string name for an ImPlotCol.
      */
     public static String getStyleColorName(final int idx) {
@@ -19837,7 +19844,7 @@ public final class ImPlot {
         return env->NewStringUTF(ImPlot::GetStyleColorName(idx));
     */
 
-    /**
+     /**
      * Returns the null terminated string name for an ImPlotMarker.
      */
     public static String getMarkerName(final int idx) {
@@ -19932,7 +19939,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Returns the number of available colormaps (i.e. the built-in + user-added count).
      */
     public static int getColormapCount() {
@@ -19943,7 +19950,7 @@ public final class ImPlot {
         return ImPlot::GetColormapCount();
     */
 
-    /**
+     /**
      * Returns a string name for a colormap given an index.
      */
     public static String getColormapName(final int cmap) {
@@ -19954,7 +19961,7 @@ public final class ImPlot {
         return env->NewStringUTF(ImPlot::GetColormapName(cmap));
     */
 
-    /**
+     /**
      * Returns an index number for a colormap given a valid string name. Returns -1 if the name is invalid.
      */
     public static int getColormapIndex(final String name) {
@@ -19968,7 +19975,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Temporarily switch to one of the built-in (i.e. ImPlotColormap_XXX) or user-added colormaps (i.e. a return value of AddColormap). Don't forget to call PopColormap!
      */
     public static void pushColormap(final int cmap) {
@@ -19979,7 +19986,7 @@ public final class ImPlot {
         ImPlot::PushColormap(cmap);
     */
 
-    /**
+     /**
      * Push a colormap by string name. Use built-in names such as "Default", "Deep", "Jet", etc. or a string you provided to AddColormap. Don't forget to call PopColormap!
      */
     public static void pushColormap(final String name) {
@@ -19992,7 +19999,7 @@ public final class ImPlot {
         if (name != NULL) env->ReleaseStringUTFChars(obj_name, name);
     */
 
-    /**
+     /**
      * Undo temporary colormap modification(s). Undo multiple pushes at once by increasing count.
      */
     public static void popColormap() {
@@ -20014,7 +20021,7 @@ public final class ImPlot {
         ImPlot::PopColormap(count);
     */
 
-    /**
+     /**
      * Returns the next color from the current colormap and advances the colormap for the current plot.
      * Can also be used with no return value to skip colors if desired. You need to call this between Begin/EndPlot!
      */
@@ -20084,7 +20091,7 @@ public final class ImPlot {
         return ImPlot::NextColormapColor().w;
     */
 
-    /**
+     /**
      * Returns the size of a colormap.
      */
     public static int getColormapSize() {
@@ -20106,7 +20113,7 @@ public final class ImPlot {
         return ImPlot::GetColormapSize(cmap);
     */
 
-    /**
+     /**
      * Returns a color from a colormap given an index {@code >=} 0 (modulo will be performed).
      */
     public static ImVec4 getColormapColor(final int idx) {
@@ -20234,7 +20241,7 @@ public final class ImPlot {
         return ImPlot::GetColormapColor(idx, cmap).w;
     */
 
-    /**
+     /**
      * Sample a color from a colormap given t between 0 and 1
      */
     public static ImVec4 sampleColormap(final float t) {
@@ -20362,7 +20369,7 @@ public final class ImPlot {
         return ImPlot::SampleColormap(t, cmap).w;
     */
 
-    /**
+     /**
      * Shows a vertical color scale with linear spaced ticks using the specified color map. Use double hashes to hide label (e.g. "##NoLabel").
      */
     public static void colormapScale(final String label, final double scaleMin, final double scaleMax) {
@@ -20514,7 +20521,7 @@ public final class ImPlot {
         if (label != NULL) env->ReleaseStringUTFChars(obj_label, label);
     */
 
-    /**
+     /**
      * Shows a horizontal slider with a colormap gradient background.
      * TODO: support our argument
      */
@@ -20586,7 +20593,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows a button with a colormap gradient brackground.
      */
     public static boolean colormapButton(final String label) {
@@ -20658,7 +20665,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * When items in a plot sample their color from a colormap, the color is cached and does not change
      * unless explicitly overriden. Therefore, if you change the colormap after the item has already been plotted,
      * item colors will NOT update. If you need item colors to resample the new colormap, then use this
@@ -20698,7 +20705,7 @@ public final class ImPlot {
     // [SECTION] Input Mapping
     //-----------------------------------------------------------------------------
 
-    private static final ImPlotInputMap _GETINPUTMAP_1 = new ImPlotInputMap(0);
+     private static final ImPlotInputMap _GETINPUTMAP_1 = new ImPlotInputMap(0);
 
     /**
      * Provides access to the input mapping structure for permanent modifications to controls for pan, select, etc.
@@ -20712,7 +20719,7 @@ public final class ImPlot {
         return (uintptr_t)&ImPlot::GetInputMap();
     */
 
-    /**
+     /**
      * Default input mapping: pan = LMB drag, box select = RMB drag,
      * fit = LMB double click, context menu = RMB click, zoom = scroll.
      */
@@ -20736,7 +20743,7 @@ public final class ImPlot {
         ImPlot::MapInputDefault(reinterpret_cast<ImPlotInputMap*>(dst));
     */
 
-    /**
+     /**
      * Reverse input mapping: pan = RMB drag, box select = LMB drag,
      * fit = LMB double click, context menu = RMB click, zoom = scroll.
      */
@@ -20795,7 +20802,7 @@ public final class ImPlot {
         ImPlot::ColormapIcon(cmap);
     */
 
-    /**
+     /**
      * Get the plot draw list for custom rendering to the current plot area. Call between Begin/EndPlot.
      */
     public static ImDrawList getPlotDrawList() {
@@ -20806,7 +20813,7 @@ public final class ImPlot {
         return (uintptr_t)ImPlot::GetPlotDrawList();
     */
 
-    /**
+     /**
      * Push clip rect for rendering to current plot area. The rect can be expanded or contracted by #expand pixels. Call between Begin/EndPlot.
      */
     public static void pushPlotClipRect() {
@@ -20828,7 +20835,7 @@ public final class ImPlot {
         ImPlot::PushPlotClipRect(expand);
     */
 
-    /**
+     /**
      * Pop plot clip rect. Call between Begin/EndPlot.
      */
     public static void popPlotClipRect() {
@@ -20839,7 +20846,7 @@ public final class ImPlot {
         ImPlot::PopPlotClipRect();
     */
 
-    /**
+     /**
      * Shows ImPlot style selector dropdown menu.
      */
     public static boolean showStyleSelector(final String label) {
@@ -20853,7 +20860,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows ImPlot colormap selector dropdown menu.
      */
     public static boolean showColormapSelector(final String label) {
@@ -20867,7 +20874,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows ImPlot input map selector dropdown menu.
      */
     public static boolean showInputMapSelector(final String label) {
@@ -20881,7 +20888,7 @@ public final class ImPlot {
         return _result;
     */
 
-    /**
+     /**
      * Shows ImPlot style editor block (not a window).
      */
     public static void showStyleEditor() {
@@ -20903,7 +20910,7 @@ public final class ImPlot {
         ImPlot::ShowStyleEditor(reinterpret_cast<ImPlotStyle*>(ref));
     */
 
-    /**
+     /**
      * Add basic help/info block for end users (not a window).
      */
     public static void showUserGuide() {
@@ -20914,7 +20921,7 @@ public final class ImPlot {
         ImPlot::ShowUserGuide();
     */
 
-    /**
+     /**
      * Shows ImPlot metrics/debug information window.
      */
     public static void showMetricsWindow() {
@@ -20942,7 +20949,7 @@ public final class ImPlot {
     // [SECTION] Demo
     //-----------------------------------------------------------------------------
 
-    /**
+     /**
      * Shows the ImPlot demo window.
      */
     public static void showDemoWindow() {

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotInputMap.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotInputMap.java
@@ -2,6 +2,9 @@ package imgui.extension.implot;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 public final class ImPlotInputMap extends ImGuiStructDestroyable {
     public ImPlotInputMap() {
         super();
@@ -25,7 +28,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         return (uintptr_t)(new ImPlotInputMap());
     */
 
-    /**
+     /**
      * LMB enables panning when held
      */
     public int getPan() {
@@ -47,7 +50,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->Pan = value;
     */
 
-    /**
+     /**
      * Optional modifier that must be held for panning/fitting
      */
     public int getPanMod() {
@@ -69,7 +72,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->PanMod = value;
     */
 
-    /**
+     /**
      * LMB initiates fit when double clicked
      */
     public int getFit() {
@@ -91,7 +94,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->Fit = value;
     */
 
-    /**
+     /**
      * RMB begins box selection when pressed and confirms
      * selection when released
      */
@@ -115,7 +118,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->Select = value;
     */
 
-    /**
+     /**
      * LMB cancels active box selection when pressed;
      * cannot be the same as Select
      */
@@ -139,7 +142,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->SelectCancel = value;
     */
 
-    /**
+     /**
      * Optional modifier that must be held for box selection
      */
     public int getSelectMod() {
@@ -161,7 +164,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->SelectMod = value;
     */
 
-    /**
+     /**
      * Alt expands active box selection horizontally
      * to plot edge when held
      */
@@ -185,7 +188,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->SelectHorzMod = value;
     */
 
-    /**
+     /**
      * Shift expands active box selection vertically
      * to plot edge when held
      */
@@ -209,7 +212,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->SelectVertMod = value;
     */
 
-    /**
+     /**
      * RMB opens context menus (if enabled) when clicked
      */
     public int getMenu() {
@@ -231,7 +234,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->Menu = value;
     */
 
-    /**
+     /**
      * Ctrl when held, all input is ignored;
      * used to enable axis/plots as DND sources
      */
@@ -255,7 +258,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->OverrideMod = value;
     */
 
-    /**
+     /**
      * Optional modifier that must be held for scroll wheel zooming
      */
     public int getZoomMod() {
@@ -277,7 +280,7 @@ public final class ImPlotInputMap extends ImGuiStructDestroyable {
         THIS->ZoomMod = value;
     */
 
-    /**
+     /**
      * Zoom rate for scroll (e.g. 0.1f = 10% plot range every scroll click);
      * make negative to invert
      */

--- a/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotStyle.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/ImPlotStyle.java
@@ -4,6 +4,10 @@ import imgui.ImVec2;
 import imgui.ImVec4;
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
 public final class ImPlotStyle extends ImGuiStructDestroyable {
     public ImPlotStyle() {
         super();

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotAxis.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotAxis.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotAxis {
     private ImPlotAxis() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotAxisFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotAxisFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotAxisFlags {
     private ImPlotAxisFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBarGroupsFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBarGroupsFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotBarGroupsFlags {
     private ImPlotBarGroupsFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBarsFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBarsFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotBarsFlags {
     private ImPlotBarsFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBin.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotBin.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotBin {
     private ImPlotBin() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCol.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCol.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotCol {
     private ImPlotCol() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotColormap.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotColormap.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotColormap {
     private ImPlotColormap() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCond.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotCond.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotCond {
     private ImPlotCond() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotDragToolFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotDragToolFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotDragToolFlags {
     private ImPlotDragToolFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotErrorBarsFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotErrorBarsFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotErrorBarsFlags {
     private ImPlotErrorBarsFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotFlags {
     private ImPlotFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotHeatmapFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotHeatmapFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotHeatmapFlags {
     private ImPlotHeatmapFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotHistogramFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotHistogramFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotHistogramFlags {
     private ImPlotHistogramFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotInfLinesFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotInfLinesFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotInfLinesFlags {
     private ImPlotInfLinesFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotItemFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotItemFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotItemFlags {
     private ImPlotItemFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLegendFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLegendFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotLegendFlags {
     private ImPlotLegendFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLineFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLineFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotLineFlags {
     private ImPlotLineFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLocation.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotLocation.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotLocation {
     private ImPlotLocation() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMarker.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMarker.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotMarker {
     private ImPlotMarker() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMouseTextFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotMouseTextFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotMouseTextFlags {
     private ImPlotMouseTextFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotPieChartFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotPieChartFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotPieChartFlags {
     private ImPlotPieChartFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotScale.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotScale.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotScale {
     private ImPlotScale() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotScatterFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotScatterFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotScatterFlags {
     private ImPlotScatterFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStairsFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStairsFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotStairsFlags {
     private ImPlotStairsFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStemsFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStemsFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotStemsFlags {
     private ImPlotStemsFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotStyleVar.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotStyleVar {
     private ImPlotStyleVar() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotTextFlags.java
+++ b/imgui-binding/src/generated/java/imgui/extension/implot/flag/ImPlotTextFlags.java
@@ -1,6 +1,9 @@
 package imgui.extension.implot.flag;
 
 
+
+
+
 public final class ImPlotTextFlags {
     private ImPlotTextFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/memedit/MemoryEditor.java
+++ b/imgui-binding/src/generated/java/imgui/extension/memedit/MemoryEditor.java
@@ -2,10 +2,16 @@ package imgui.extension.memedit;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
+
 /**
  * ImGui Club Memory Editor extension for ImGui
  * Repo: <a href="https://github.com/ocornut/imgui_club">https://github.com/ocornut/imgui_club</a>
  */
+
 public final class MemoryEditor extends ImGuiStructDestroyable {
     public MemoryEditor() {
         super();

--- a/imgui-binding/src/generated/java/imgui/extension/memedit/MemoryEditorSizes.java
+++ b/imgui-binding/src/generated/java/imgui/extension/memedit/MemoryEditorSizes.java
@@ -2,6 +2,9 @@ package imgui.extension.memedit;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
 public final class MemoryEditorSizes extends ImGuiStructDestroyable {
     public MemoryEditorSizes() {
         super();

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditor.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditor.java
@@ -3,6 +3,11 @@ package imgui.extension.nodeditor;
 import imgui.ImDrawList;
 import imgui.ImVec2;
 import imgui.ImVec4;
+
+
+
+
+
 import imgui.type.ImLong;
 
 /**
@@ -21,6 +26,7 @@ import imgui.type.ImLong;
  * Binding notice: instead of special types for ids of nodes, links and pins which used in native library
  * we use longs to reduce boilerplate and garbage production
  */
+
 public final class NodeEditor {
     private NodeEditor() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditorConfig.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditorConfig.java
@@ -2,6 +2,10 @@ package imgui.extension.nodeditor;
 
 import imgui.binding.ImGuiStructDestroyable;
 
+
+
+
+
 public final class NodeEditorConfig extends ImGuiStructDestroyable {
     @Override
     protected long create() {

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditorStyle.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/NodeEditorStyle.java
@@ -4,6 +4,10 @@ import imgui.ImVec2;
 import imgui.ImVec4;
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
 public final class NodeEditorStyle extends ImGuiStruct {
     public NodeEditorStyle(final long ptr) {
         super(ptr);

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorCanvasSizeMode.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorCanvasSizeMode.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorCanvasSizeMode {
     private NodeEditorCanvasSizeMode() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorFlowDirection.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorFlowDirection.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorFlowDirection {
     private NodeEditorFlowDirection() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorPinKind.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorPinKind.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorPinKind {
     private NodeEditorPinKind() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorStyleColor.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorStyleColor.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorStyleColor {
     private NodeEditorStyleColor() {
     }

--- a/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/extension/nodeditor/flag/NodeEditorStyleVar.java
@@ -1,6 +1,9 @@
 package imgui.extension.nodeditor.flag;
 
 
+
+
+
 public final class NodeEditorStyleVar {
     private NodeEditorStyleVar() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImDrawFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImDrawFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImDrawList functions
  */
+
 public final class ImDrawFlags {
     private ImDrawFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImDrawListFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImDrawListFlags.java
@@ -1,10 +1,13 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImDrawList. Those are set automatically by ImGui:: functions from ImGuiIO settings, and generally not manipulated directly.
  * It is however possible to temporarily alter flags between calls to ImDrawList:: functions.
  */
+
 public final class ImDrawListFlags {
     private ImDrawListFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImFontAtlasFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImFontAtlasFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImFontAtlas build
  */
+
 public final class ImFontAtlasFlags {
     private ImFontAtlasFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiBackendFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiBackendFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Backend capabilities flags stored in io.BackendFlags. Set by imgui_impl_xxx or custom backend.
  */
+
 public final class ImGuiBackendFlags {
     private ImGuiBackendFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiButtonFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiButtonFlags.java
@@ -1,6 +1,9 @@
 package imgui.flag;
 
 
+
+
+
 public final class ImGuiButtonFlags {
     private ImGuiButtonFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiCol.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiCol.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for PushStyleColor() / PopStyleColor()
  */
+
 public final class ImGuiCol {
     private ImGuiCol() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiColorEditFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiColorEditFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ColorEdit3() / ColorEdit4() / ColorPicker3() / ColorPicker4() / ColorButton()
  */
+
 public final class ImGuiColorEditFlags {
     private ImGuiColorEditFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiComboFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiComboFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginCombo()
  */
+
 public final class ImGuiComboFlags {
     private ImGuiComboFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiCond.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiCond.java
@@ -1,11 +1,14 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for ImGui::SetWindow***(), SetNextWindow***(), SetNextItem***() functions
  * Represent a condition.
  * Important: Treat as a regular enum! Do NOT combine multiple values using binary operators! All the functions above treat 0 as a shortcut to ImGuiCond_Always.
  */
+
 public final class ImGuiCond {
     private ImGuiCond() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiConfigFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiConfigFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Configuration flags stored in io.ConfigFlags. Set by user/application.
  */
+
 public final class ImGuiConfigFlags {
     private ImGuiConfigFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiDataType.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiDataType.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * A primary data type
  */
+
 public final class ImGuiDataType {
     private ImGuiDataType() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiDir.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiDir.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * A cardinal direction
  */
+
 public final class ImGuiDir {
     private ImGuiDir() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiDockNodeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiDockNodeFlags.java
@@ -1,10 +1,13 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::DockSpace(), shared/inherited by child nodes.
  * (Some flags can be applied to individual nodes directly)
  */
+
 public final class ImGuiDockNodeFlags {
     private ImGuiDockNodeFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiDragDropFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiDragDropFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginDragDropSource(), ImGui::AcceptDragDropPayload()
  */
+
 public final class ImGuiDragDropFlags {
     private ImGuiDragDropFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiFocusedFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiFocusedFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::IsWindowFocused()
  */
+
 public final class ImGuiFocusedFlags {
     private ImGuiFocusedFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiFreeTypeBuilderFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiFreeTypeBuilderFlags.java
@@ -1,6 +1,9 @@
 package imgui.flag;
 
 
+
+
+
 public final class ImGuiFreeTypeBuilderFlags {
     private ImGuiFreeTypeBuilderFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiHoveredFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiHoveredFlags.java
@@ -1,11 +1,14 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::IsItemHovered(), ImGui::IsWindowHovered()
  * Note:if you are trying to check whether your mouse should be dispatched to Dear ImGui or to your app,
  * you should use'io.WantCaptureMouse'instead!Please read the FAQ!Note: windows with the ImGuiWindowFlags_NoInputs flag are ignored by IsWindowHovered() calls.
  */
+
 public final class ImGuiHoveredFlags {
     private ImGuiHoveredFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiInputTextFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiInputTextFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::InputText()
  */
+
 public final class ImGuiInputTextFlags {
     private ImGuiInputTextFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiKey.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiKey.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * A key identifier (ImGuiKey_XXX or ImGuiMod_XXX value): can represent Keyboard, Mouse and Gamepad values.
  * All our named keys are {@code >=} 512. Keys value 0 to 511 are left unused as legacy native/opaque key values ({@code <} 1.87).
@@ -8,6 +10,7 @@ package imgui.flag;
  * Read details about the 1.87 and 1.89 transition : https://github.com/ocornut/imgui/issues/4921
  * Note that "Keys" related to physical keys and are not the same concept as input "Characters", the later are submitted via io.AddInputCharacter().
  */
+
 public final class ImGuiKey {
     private ImGuiKey() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseButton.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseButton.java
@@ -1,10 +1,13 @@
 package imgui.flag;
 
 
+
+
 /**
  * Identify a mouse button.
  * Those values are guaranteed to be stable and we frequently use 0/1 directly. Named enums provided for convenience.
  */
+
 public final class ImGuiMouseButton {
     private ImGuiMouseButton() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseCursor.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseCursor.java
@@ -1,10 +1,13 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for GetMouseCursor()
  * User code may request binding to display given cursor by calling SetMouseCursor(), which is why we have some cursors that are marked unused here
  */
+
 public final class ImGuiMouseCursor {
     private ImGuiMouseCursor() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseSource.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiMouseSource.java
@@ -1,12 +1,15 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for AddMouseSourceEvent() actual source of Mouse Input data.
  * Historically we use "Mouse" terminology everywhere to indicate pointer data, e.g. MousePos, IsMousePressed(), io.AddMousePosEvent()
  * But that "Mouse" data can come from different source which occasionally may be useful for application to know about.
  * You can submit a change of pointer type using io.AddMouseSourceEvent().
  */
+
 public final class ImGuiMouseSource {
     private ImGuiMouseSource() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiPopupFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiPopupFlags.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for OpenPopup*(), BeginPopupContext*(), IsPopupOpen() functions.
  * - To be backward compatible with older API which took an 'int mouse_button = 1' argument, we need to treat
@@ -9,6 +11,7 @@ package imgui.flag;
  * - For the same reason, we exceptionally default the ImGuiPopupFlags argument of BeginPopupContextXXX functions to 1 instead of 0.
  * - Multiple buttons currently cannot be combined/or-ed in those functions (we could allow it later).
  */
+
 public final class ImGuiPopupFlags {
     private ImGuiPopupFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiSelectableFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiSelectableFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::Selectable()
  */
+
 public final class ImGuiSelectableFlags {
     private ImGuiSelectableFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiSliderFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiSliderFlags.java
@@ -1,6 +1,9 @@
 package imgui.flag;
 
 
+
+
+
 public final class ImGuiSliderFlags {
     private ImGuiSliderFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiSortDirection.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiSortDirection.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * A sorting direction
  */
+
 public final class ImGuiSortDirection {
     private ImGuiSortDirection() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiStyleVar.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiStyleVar.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enumeration for PushStyleVar() / PopStyleVar() to temporarily modify the ImGuiStyle structure.
  * - The enum only refers to fields of ImGuiStyle which makes sense to be pushed/popped inside UI code.
@@ -10,6 +12,7 @@ package imgui.flag;
  *   With Visual Assist installed: ALT+G ("VAssistX.GoToImplementation") can also follow symbols in comments.
  * - When changing this enum, you need to update the associated internal table GStyleVarInfo[] accordingly. This is where we link enum values to members offset/type.
  */
+
 public final class ImGuiStyleVar {
     private ImGuiStyleVar() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTabBarFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTabBarFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginTabBar()
  */
+
 public final class ImGuiTabBarFlags {
     private ImGuiTabBarFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTabItemFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTabItemFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginTabItem()
  */
+
 public final class ImGuiTabItemFlags {
     private ImGuiTabItemFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTableBgTarget.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTableBgTarget.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Enum for ImGui::TableSetBgColor()
  * Background colors are rendering in 3 layers:
@@ -12,6 +14,7 @@ package imgui.flag;
  * If you set the color of RowBg0 target, your color will override the existing RowBg0 color.
  * If you set the color of RowBg1 or ColumnBg1 target, your color will blend over the RowBg0 color.
  */
+
 public final class ImGuiTableBgTarget {
     private ImGuiTableBgTarget() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTableColumnFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTableColumnFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for {@link imgui.ImGui#tableSetupColumn(String, int)}
  */
+
 public final class ImGuiTableColumnFlags {
     private ImGuiTableColumnFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTableFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTableFlags.java
@@ -1,6 +1,8 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::BeginTable()
  * [BETA API] API may evolve slightly! If you use this, please update to the next version when it comes out!
@@ -26,6 +28,7 @@ package imgui.flag;
  * If you specify a value for 'inner_width' then effectively the scrolling space is known and Stretch or mixed Fixed/Stretch columns become meaningful again.
  * - Read on documentation at the top of imgui_tables.cpp for details.
  */
+
 public final class ImGuiTableFlags {
     private ImGuiTableFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTableRowFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTableRowFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for {@link imgui.ImGui#tableNextRow(int)}
  */
+
 public final class ImGuiTableRowFlags {
     private ImGuiTableRowFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiTreeNodeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiTreeNodeFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::TreeNodeEx(), ImGui::CollapsingHeader*()
  */
+
 public final class ImGuiTreeNodeFlags {
     private ImGuiTreeNodeFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiViewportFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiViewportFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags stored in ImGuiViewport::Flags, giving indications to the platform backends.
  */
+
 public final class ImGuiViewportFlags {
     private ImGuiViewportFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/flag/ImGuiWindowFlags.java
+++ b/imgui-binding/src/generated/java/imgui/flag/ImGuiWindowFlags.java
@@ -1,9 +1,12 @@
 package imgui.flag;
 
 
+
+
 /**
  * Flags for ImGui::Begin()
  */
+
 public final class ImGuiWindowFlags {
     private ImGuiWindowFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/ImGui.java
+++ b/imgui-binding/src/generated/java/imgui/internal/ImGui.java
@@ -6,9 +6,14 @@ import imgui.ImGuiPlatformMonitor;
 import imgui.ImGuiViewport;
 import imgui.ImVec2;
 import imgui.ImVec4;
+
+
+
+
 import imgui.type.ImBoolean;
 import imgui.type.ImFloat;
 import imgui.type.ImInt;
+
 
 public final class ImGui extends imgui.ImGui {
     /*JNI
@@ -1014,7 +1019,7 @@ public final class ImGui extends imgui.ImGui {
         return ImGui::DockBuilderAddNode(nodeId, flags);
     */
 
-    /**
+     /**
      * Remove node and all its child, undock all windows.
      */
     public static void dockBuilderRemoveNode(final int nodeId) {
@@ -1041,7 +1046,7 @@ public final class ImGui extends imgui.ImGui {
         ImGui::DockBuilderRemoveNodeDockedWindows(nodeId, clearSettingsRefs);
     */
 
-    /**
+     /**
      * Remove all split/hierarchy. All remaining docked windows will be re-docked to the remaining root node (node_id).
      */
     public static void dockBuilderRemoveNodeChildNodes(final int nodeId) {
@@ -1078,7 +1083,7 @@ public final class ImGui extends imgui.ImGui {
         ImGui::DockBuilderSetNodeSize(nodeId, size);
     */
 
-    /**
+     /**
      * Create 2 child nodes in this parent node.
      */
     public static int dockBuilderSplitNode(final int nodeId, final int splitDir, final float sizeRatioForNodeAtDir, final ImInt outIdAtDir, final ImInt outIdAtOppositeDir) {
@@ -1150,7 +1155,7 @@ public final class ImGui extends imgui.ImGui {
         ImGui::TableSetColumnSortDirection(columnN, static_cast<ImGuiSortDirection>(sortDirection), appendToSortSpecs);
     */
 
-    /**
+     /**
      * May use {@code (TableGetColumnFlags() & ImGuiTableColumnFlags_IsHovered)} instead. Return hovered column.
      * Return -1 when table is not hovered. return columns_count if the unused space at the right of visible columns is hovered.
      */
@@ -1162,7 +1167,7 @@ public final class ImGui extends imgui.ImGui {
         return ImGui::TableGetHoveredColumn();
     */
 
-    /**
+     /**
      * Retrieve *PREVIOUS FRAME* hovered row. This difference with TableGetHoveredColumn() is the reason why this is not public yet.
      */
     public static int tableGetHoveredRow() {

--- a/imgui-binding/src/generated/java/imgui/internal/ImGuiDockNode.java
+++ b/imgui-binding/src/generated/java/imgui/internal/ImGuiDockNode.java
@@ -4,6 +4,11 @@ import imgui.ImGuiWindowClass;
 import imgui.ImVec2;
 import imgui.binding.ImGuiStruct;
 
+
+
+
+
+
 public final class ImGuiDockNode extends ImGuiStruct {
     public ImGuiDockNode(final long ptr) {
         super(ptr);
@@ -32,7 +37,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->ID = value;
     */
 
-    /**
+     /**
      * Flags shared by all nodes of a same dockspace hierarchy (inherited from the root node)
      */
     public int getSharedFlags() {
@@ -75,7 +80,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->SharedFlags = value;
     */
 
-    /**
+     /**
      * Flags specific to this node
      */
     public int getLocalFlags() {
@@ -118,7 +123,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LocalFlags = value;
     */
 
-    /**
+     /**
      * Flags specific to this node, applied from windows
      */
     public int getLocalFlagsInWindows() {
@@ -161,7 +166,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LocalFlagsInWindows = value;
     */
 
-    /**
+     /**
      * Effective flags (== SharedFlags | LocalFlagsInNode | LocalFlagsInWindows)
      */
     public int getMergedFlags() {
@@ -243,7 +248,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
 
     // TODO  Windows, TabBar
 
-    /**
+     /**
      * Current position
      */
     public ImVec2 getPos() {
@@ -304,7 +309,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->Pos = value;
     */
 
-    /**
+     /**
      * Current size
      */
     public ImVec2 getSize() {
@@ -365,7 +370,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->Size = value;
     */
 
-    /**
+     /**
      * [Split node only] Last explicitly written-to size (overridden when using a splitter affecting the node), used to calculate Size.
      */
     public ImVec2 getSizeRef() {
@@ -426,7 +431,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->SizeRef = value;
     */
 
-    /**
+     /**
      * [Split node only] Split axis (X or Y)
      */
     public int getSplitAxis() {
@@ -437,7 +442,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         return THIS->SplitAxis;
     */
 
-    /**
+     /**
      * [Root node only]
      */
     public ImGuiWindowClass getWindowClass() {
@@ -480,7 +485,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->HostWindow = reinterpret_cast<ImGuiWindow*>(value);
     */
 
-    /**
+     /**
      * Generally point to window which is ID is == SelectedTabID, but when CTRL+Tabbing this can be a different window.
      */
     public ImGuiWindow getVisibleWindow() {
@@ -502,7 +507,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->VisibleWindow = reinterpret_cast<ImGuiWindow*>(value);
     */
 
-    /**
+     /**
      * [Root node only] Pointer to central node.
      */
     public ImGuiDockNode getCentralNode() {
@@ -524,7 +529,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->CentralNode = reinterpret_cast<ImGuiDockNode*>(value);
     */
 
-    /**
+     /**
      * [Root node only] Set when there is a single visible node within the hierarchy.
      */
     public ImGuiDockNode getOnlyNodeWithWindows() {
@@ -546,7 +551,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->OnlyNodeWithWindows = reinterpret_cast<ImGuiDockNode*>(value);
     */
 
-    /**
+     /**
      * Last frame number the node was updated or kept alive explicitly with DockSpace() + int_KeepAliveOnly
      */
     public int getLastFrameAlive() {
@@ -568,7 +573,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LastFrameAlive = value;
     */
 
-    /**
+     /**
      * Last frame number the node was updated.
      */
     public int getLastFrameActive() {
@@ -590,7 +595,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LastFrameActive = value;
     */
 
-    /**
+     /**
      * Last frame number the node was focused.
      */
     public int getLastFrameFocused() {
@@ -612,7 +617,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LastFrameFocused = value;
     */
 
-    /**
+     /**
      * [Root node only] Which of our child docking node (any ancestor in the hierarchy) was last focused.
      */
     public int getLastFocusedNodeId() {
@@ -634,7 +639,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->LastFocusedNodeId = value;
     */
 
-    /**
+     /**
      * [Leaf node only] Which of our tab/window is selected.
      */
     public int getSelectedTabId() {
@@ -656,7 +661,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->SelectedTabId = value;
     */
 
-    /**
+     /**
      * [Leaf node only] Set when closing a specific tab/window.
      */
     public int getWantCloseTabId() {
@@ -726,7 +731,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->AuthorityForViewport = value;
     */
 
-    /**
+     /**
      * Set to false when the node is hidden (usually disabled as it has no active window)
      */
     public boolean getIsVisible() {
@@ -812,7 +817,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->HasCentralNodeChild = value;
     */
 
-    /**
+     /**
      * Set when closing all tabs at once.
      */
     public boolean getWantCloseAll() {
@@ -850,7 +855,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         THIS->WantLockSizeOnce = value;
     */
 
-    /**
+     /**
      * After a node extraction we need to transition toward moving the newly created host window
      */
     public boolean getWantMouseMove() {
@@ -936,7 +941,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         return THIS->IsCentralNode();
     */
 
-    /**
+     /**
      * Hidden tab bar can be shown back by clicking the small triangle
      */
     public boolean isHiddenTabBar() {
@@ -947,7 +952,7 @@ public final class ImGuiDockNode extends ImGuiStruct {
         return THIS->IsHiddenTabBar();
     */
 
-    /**
+     /**
      * Never show a tab bar
      */
     public boolean isNoTabBar() {

--- a/imgui-binding/src/generated/java/imgui/internal/ImGuiWindow.java
+++ b/imgui-binding/src/generated/java/imgui/internal/ImGuiWindow.java
@@ -2,6 +2,9 @@ package imgui.internal;
 
 import imgui.binding.ImGuiStruct;
 
+
+
+
 public class ImGuiWindow extends ImGuiStruct {
     public ImGuiWindow(final long ptr) {
         super(ptr);
@@ -14,7 +17,7 @@ public class ImGuiWindow extends ImGuiStruct {
         #define THIS ((ImGuiWindow*)STRUCT_PTR)
      */
 
-    /**
+     /**
      * Is scrollbar visible?
      */
     public boolean getScrollbarX() {
@@ -25,7 +28,7 @@ public class ImGuiWindow extends ImGuiStruct {
         return THIS->ScrollbarX;
     */
 
-    /**
+     /**
      * Is scrollbar visible?
      */
     public boolean getScrollbarY() {

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiAxis.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiAxis.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public final class ImGuiAxis {
     private ImGuiAxis() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiButtonFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiButtonFlags.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public final class ImGuiButtonFlags {
     private ImGuiButtonFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDataAuthority.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDataAuthority.java
@@ -1,9 +1,12 @@
 package imgui.internal.flag;
 
 
+
+
 /**
  * Store the source authority (dock node vs window) of a field
  */
+
 public final class ImGuiDataAuthority {
     private ImGuiDataAuthority() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeFlags.java
@@ -1,9 +1,12 @@
 package imgui.internal.flag;
 
 
+
+
 /**
  * Extend ImGuiDockNodeFlags
  */
+
 public final class ImGuiDockNodeFlags {
     private ImGuiDockNodeFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeState.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiDockNodeState.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public final class ImGuiDockNodeState {
     private ImGuiDockNodeState() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiFocusRequestFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiFocusRequestFlags.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public final class ImGuiFocusRequestFlags {
     private ImGuiFocusRequestFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiItemFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiItemFlags.java
@@ -1,10 +1,13 @@
 package imgui.internal.flag;
 
 
+
+
 /**
  * Transient per-window flags, reset at the beginning of the frame. For child window, inherited from parent on first Begin().
  * This is going to be exposed in imgui.h when stabilized enough.
  */
+
 public final class ImGuiItemFlags {
     private ImGuiItemFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiItemStatusFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiItemStatusFlags.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public class ImGuiItemStatusFlags {
     private ImGuiItemStatusFlags() {
     }

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiSeparatorFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiSeparatorFlags.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public class ImGuiSeparatorFlags {
 
     /**

--- a/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiTextFlags.java
+++ b/imgui-binding/src/generated/java/imgui/internal/flag/ImGuiTextFlags.java
@@ -1,6 +1,9 @@
 package imgui.internal.flag;
 
 
+
+
+
 public class ImGuiTextFlags {
 
     /**

--- a/imgui-binding/src/main/java/imgui/ImGui.java
+++ b/imgui-binding/src/main/java/imgui/ImGui.java
@@ -2934,4 +2934,31 @@ public class ImGui {
      */
     @BindingMethod
     public static native ImGuiViewport FindViewportByPlatformHandle(@ArgValue(callPrefix = "(void*)") long platformHandle);
+
+    @BindingMethod
+    public static native void BeginHorizontal(String str_id, @OptArg(callValue = "ImVec2(0,0)") ImVec2 size, @OptArg float align);
+
+    @BindingMethod
+    public static native void BeginHorizontal(int id, @OptArg(callValue = "ImVec2(0,0)") ImVec2 size, @OptArg float align);
+
+    @BindingMethod
+    public static native void EndHorizontal();
+
+    @BindingMethod
+    public static native void BeginVertical(String str_id, @OptArg(callValue = "ImVec2(0,0)") ImVec2 size, @OptArg float align);
+
+    @BindingMethod
+    public static native void BeginVertical(int id, @OptArg(callValue = "ImVec2(0,0)") ImVec2 size, @OptArg float align);
+
+    @BindingMethod
+    public static native void EndVertical();
+
+    @BindingMethod
+    public static native void Spring(@OptArg float weight, @OptArg float spacing);
+
+    @BindingMethod
+    public static native void SuspendLayout();
+
+    @BindingMethod
+    public static native void ResumeLayout();
 }


### PR DESCRIPTION
Layouts from the NodeEditor solution have been added for a more convenient layout of elements. It is mainly used when creating nodes in NodeEditor.

### New methods
- beginHorizontal
- endHorizontal
- beginVertical
- endVertical
- spring
- suspendLayout
- resumeLayout

<!-- 
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
-->

## Type of change

<!-- 
Please check options that are relevant.
-->

- [ ] Minor changes or tweaks (quality of life stuff)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
